### PR TITLE
ci: replace the retired Go Report Card badge with a golangci-lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,30 @@ jobs:
             exit 1
           fi
 
+  # Static analysis beyond `go vet`. Ubuntu only: the linters are
+  # platform-independent, and running them three times says the same thing
+  # three times.
+  #
+  # This replaces the Go Report Card badge the README used to carry. That
+  # service is retired -- its badge now renders the word "retired" -- and its
+  # own site points at golangci-lint instead.
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      # The linter version is pinned, unlike the actions above. A new
+      # golangci-lint release can add checks, and a green branch turning red
+      # because a tool updated overnight is not a signal about this repo.
+      - uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.13.1
+
   # The language side. Ubuntu only: both scripts need bash 4 (mapfile) and GNU
   # coreutils (timeout), and the macOS runner ships bash 3.2 with neither.
   language:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,45 @@
+# golangci-lint configuration.
+#
+# Go Report Card, which the README used to badge, is retired; its own site now
+# points at golangci-lint. This runs in CI as the `lint` job, so the CI badge
+# covers it.
+#
+# `go vet`, `gofmt` and `go test` still run separately in CI. They are the
+# checks CLAUDE.md tells a contributor to run locally, and they should not
+# require installing anything.
+version: "2"
+
+linters:
+  default: standard # errcheck, govet, ineffassign, staticcheck, unused
+  enable:
+    - errorlint # errors compared with == rather than errors.Is
+    - misspell # the comments here carry most of the design rationale
+    - predeclared # a local named `len` or `new` shadowing the builtin
+    - unconvert # conversions that do nothing
+    - usestdlibvars # http.MethodGet and friends over string literals
+
+  settings:
+    errcheck:
+      # Writing a diagnostic to a stream and ignoring the result is deliberate:
+      # if stderr is gone there is nothing useful left to do about it, and the
+      # alternative is `_ =` on every message the interpreter prints.
+      exclude-functions:
+        - fmt.Fprint
+        - fmt.Fprintf
+        - fmt.Fprintln
+
+    staticcheck:
+      checks:
+        - all
+        # QF are editor quickfixes rather than defects. QF1006 wants
+        # `for cond() {}` where interp.loop spells the break out; the explicit
+        # form reads better next to the signal handling around it.
+        - -QF1006
+
+  exclusions:
+    rules:
+      # A test that ignores an error is usually asserting something else about
+      # the call; the assertion is the check.
+      - path: _test\.go
+        linters:
+          - errcheck

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,17 @@ scripts/check-readme.sh        # -v to see each block's output
 Keep them runnable. A block that is prose, not code, should not be fenced as `swift` — the
 checker will try to run it.
 
+## Pull requests
+
+Keep the body to two parts: a sentence or two on why the change exists, then a
+`## What changed` list of what it does. That is the whole convention.
+
+The reasoning goes in the commit messages, where it stays attached to the lines it
+explains instead of to a branch that may get force-pushed out from under it. A PR body
+that restates the commits goes stale immediately and gets read twice by nobody.
+
+End at the content. No generated-with footer.
+
 ## Releasing
 
 Tags are `vX.Y.Z`. The `v` is not decoration: the module proxy only recognises a

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![CI](https://github.com/fadion/aria/actions/workflows/ci.yml/badge.svg)](https://github.com/fadion/aria/actions/workflows/ci.yml)
 [![Go Reference](https://pkg.go.dev/badge/github.com/fadion/aria.svg)](https://pkg.go.dev/github.com/fadion/aria)
-[![Go Report Card](https://goreportcard.com/badge/github.com/fadion/aria)](https://goreportcard.com/report/github.com/fadion/aria)
 
 # Aria Language
 

--- a/internal/diag/diag.go
+++ b/internal/diag/diag.go
@@ -59,8 +59,8 @@ type Bag struct {
 // New returns a Bag for file, keeping at most DefaultMax diagnostics.
 func New(file *source.File) *Bag { return &Bag{file: file, max: DefaultMax} }
 
-// SetMax changes the cap. A max of zero or less means unlimited.
-func (b *Bag) SetMax(max int) { b.max = max }
+// SetMax changes the cap. A cap of zero or less means unlimited.
+func (b *Bag) SetMax(n int) { b.max = n }
 
 // Errorf records an error covering span.
 func (b *Bag) Errorf(span source.Span, format string, args ...any) {

--- a/internal/interp/builtins.go
+++ b/internal/interp/builtins.go
@@ -86,7 +86,7 @@ func (i *Interp) installBuiltins() {
 		}
 		// The range is inclusive. The original called rand.Intn(max-min), which
 		// panicked the whole process when min equalled max.
-		return value.Int(lo + value.Int(rand.N(int64(hi-lo)+1)))
+		return lo + value.Int(rand.N(int64(hi-lo)+1))
 	})
 
 	def("runtime_tolower", func(ip *Interp, args []value.Value, span source.Span) value.Value {

--- a/internal/interp/run.go
+++ b/internal/interp/run.go
@@ -1,6 +1,7 @@
 package interp
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -71,8 +72,8 @@ func Run(file *source.File, opts Options) bool {
 	i.info = info
 
 	if _, err := i.Run(prog); err != nil {
-		re, ok := err.(*Error)
-		if !ok {
+		var re *Error
+		if !errors.As(err, &re) {
 			fmt.Fprintln(opts.Err, err)
 			return false
 		}
@@ -114,8 +115,8 @@ func (i *Interp) loadStdlib(errOut io.Writer) bool {
 			dir: ".", imported: i.imported,
 		}
 		if _, err := sub.Run(prog); err != nil {
-			re, ok := err.(*Error)
-			if ok {
+			var re *Error
+			if errors.As(err, &re) {
 				sub.Report(re)
 			} else {
 				fmt.Fprintln(errOut, err)
@@ -258,7 +259,8 @@ func (s *Session) Eval(src string) (value.Value, error) {
 
 	v, err := s.interp.Run(prog)
 	if err != nil {
-		if re, ok := err.(*Error); ok {
+		var re *Error
+		if errors.As(err, &re) {
 			b := diag.New(file)
 			b.Errorf(re.Span, "%s", re.Msg)
 			return nil, fmt.Errorf("%s", strings.TrimRight(b.Render(), "\n"))


### PR DESCRIPTION
The `Go Report Card` badge in the README is dead. The service is retired and its badge endpoint now renders the literal text `go report: retired`, so the README was advertising nothing. Go Report Card's own site points at [golangci-lint](https://golangci-lint.run/) instead — so rather than just deleting the line, this adds the static analysis it stood for.

## What changed

- Removed the badge from the README. No replacement badge; golangci-lint has no hosted equivalent and the CI badge already covers the new job.
- Added a `lint` job to `.github/workflows/ci.yml`, Ubuntu only, with the golangci-lint version pinned.
- Added `.golangci.yml`: the standard five plus `errorlint`, `misspell`, `predeclared`, `unconvert` and `usestdlibvars`. Two exclusions, both commented in the file.
- Fixed the five findings it reported — three `err.(*Error)` assertions to `errors.As`, a parameter shadowing the `max` builtin, and a redundant conversion. Separate commit, so that one leaves the tree green.
- Recorded the PR body convention in `CLAUDE.md`.
