### PR TITLE
Locate a runtime error in the file its span indexes into

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ go test ./internal/parser/  -run=Fuzz -fuzz=FuzzParse -fuzztime=30s
 
 ## The characterization suite is the arbiter
 
-`testdata/semantics/` holds 128 `.ari` files, each with a `.out` golden recording exactly
+`testdata/semantics/` holds 131 `.ari` files, each with a `.out` golden recording exactly
 what the interpreter prints and what it exits with.
 
 **If a golden changes, you changed the language.** That is either the point of your change

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -234,9 +234,33 @@ main.ari:3:11: error: unterminated string
 A failed run exits non-zero. The original exited `0` on every parse and runtime error
 alike, which made failure undetectable from a script.
 
+### A runtime error carries the file its span indexes into
+
+A `source.Span` is a pair of byte offsets and nothing else, so it only means something
+against the file it was taken from. One program routinely evaluates code from three: the
+file being run, whatever it imports, and the standard library. Rendering every span
+against the file being run drew the importer's text at the importee's offsets — an
+unrelated line with a caret under nothing — and for the standard library the offset
+usually landed past the end of the user's file, which produced a line number that did not
+exist and no source line at all.
+
+So `interp.Error` carries a `*source.File` alongside its span, and the interpreter keeps a
+stack of call frames. A `*Function` records the file its body was written in; calling it
+pushes a frame naming that file, and `fail` locates the error in the innermost frame's
+file. Errors reported *at* a call — arity, parameter types, return type — are faults in
+the caller, so they go through `failIn` with the caller's file explicitly.
+
+### Recursion is bounded
+
+The parser bounds nesting at 250 so that deep input fails with a diagnostic instead of
+exhausting the stack. The evaluator now does the same at `maxCallDepth`, 3000 frames: past
+that a call fails as an ordinary Aria error. Without it, runaway recursion grew the
+goroutine stack to Go's 1 GB ceiling and killed the process with a traceback, which is not
+something the author of an Aria program can act on.
+
 ## The characterization suite
 
-`testdata/semantics/` holds 128 cases. Each `.ari` file has a `.out` golden recording
+`testdata/semantics/` holds 131 cases. Each `.ari` file has a `.out` golden recording
 exactly what the interpreter prints and what it exits with.
 
 ```bash

--- a/internal/interp/callable.go
+++ b/internal/interp/callable.go
@@ -7,9 +7,15 @@ import (
 )
 
 // Function is a user-defined function closed over its defining scope.
+//
+// File is where the body was written, which the interpreter running the call
+// need not know otherwise: a standard library function is called by the
+// interpreter for the user's file, and a fault in its body belongs to the
+// library's text, not the user's.
 type Function struct {
 	Decl *ast.Function
 	Env  *env
+	File *source.File
 }
 
 func (*Function) Type() value.Type { return value.TFunc }
@@ -88,7 +94,19 @@ func (i *Interp) apply(callee value.Value, args []value.Value, span source.Span,
 }
 
 // callFunction binds arguments to parameters and runs the body.
+//
+// Everything reported against span — arity, parameter and return types — is a
+// fault at the *call site*, so it is located in the caller's file. Everything
+// reported from inside the body, defaults included, belongs to the file the
+// body was written in, which is what the pushed frame supplies.
 func (i *Interp) callFunction(fn *Function, args []value.Value, span source.Span) value.Value {
+	callerFile := i.curFile()
+	if len(i.frames) >= maxCallDepth {
+		i.failIn(callerFile, span, "call depth of %d exceeded, probably infinite recursion", maxCallDepth)
+	}
+	i.frames = append(i.frames, frame{file: fn.File, span: span})
+	defer func() { i.frames = i.frames[:len(i.frames)-1] }()
+
 	decl := fn.Decl
 	scope := newEnv(fn.Env)
 
@@ -110,15 +128,15 @@ func (i *Interp) callFunction(fn *Function, args []value.Value, span source.Span
 	}
 
 	if len(args) < required {
-		i.fail(span, "%s expects at least %d argument(s), got %d", fnName(decl), required, len(args))
+		i.failIn(callerFile, span, "%s expects at least %d argument(s), got %d", fnName(decl), required, len(args))
 	}
 	if !decl.Variadic && len(args) > fixed {
-		i.fail(span, "%s expects at most %d argument(s), got %d", fnName(decl), fixed, len(args))
+		i.failIn(callerFile, span, "%s expects at most %d argument(s), got %d", fnName(decl), fixed, len(args))
 	}
 
 	for idx := 0; idx < fixed && idx < len(args); idx++ {
 		p := decl.Parameters[idx]
-		i.checkParamType(p, args[idx], span)
+		i.checkParamType(p, args[idx], callerFile, span)
 		scope.define(p.Name.Value, args[idx])
 	}
 
@@ -140,18 +158,18 @@ func (i *Interp) callFunction(fn *Function, args []value.Value, span source.Span
 	}
 
 	if decl.ReturnType != nil && result.Type().String() != decl.ReturnType.Value {
-		i.fail(span, "%s declares it returns %s but returned %s",
+		i.failIn(callerFile, span, "%s declares it returns %s but returned %s",
 			fnName(decl), decl.ReturnType.Value, result.Type())
 	}
 	return result
 }
 
-func (i *Interp) checkParamType(p *ast.FunctionParameter, arg value.Value, span source.Span) {
+func (i *Interp) checkParamType(p *ast.FunctionParameter, arg value.Value, file *source.File, span source.Span) {
 	if p.Type == nil {
 		return
 	}
 	if arg.Type().String() != p.Type.Value {
-		i.fail(span, "parameter '%s' expects %s, got %s", p.Name.Value, p.Type.Value, arg.Type())
+		i.failIn(file, span, "parameter '%s' expects %s, got %s", p.Name.Value, p.Type.Value, arg.Type())
 	}
 }
 

--- a/internal/interp/interp.go
+++ b/internal/interp/interp.go
@@ -34,7 +34,13 @@ import (
 )
 
 // Error is a runtime failure, located in the source.
+//
+// File is the file Span indexes into, which is not necessarily the file that
+// was run: a fault inside an imported file or a standard library module is
+// located in that file's text. Without it the span was rendered against the
+// wrong source and pointed at unrelated lines, or past the end of the file.
 type Error struct {
+	File *source.File
 	Span source.Span
 	Msg  string
 }
@@ -106,6 +112,26 @@ type Interp struct {
 
 	signal signal
 	retval value.Value
+
+	// frames is the call stack. Each frame names the file its function's body
+	// lives in, so a fault inside it is reported against that file, and its
+	// depth is what bounds recursion.
+	frames []frame
+}
+
+// maxCallDepth bounds recursion, for the reason the parser bounds nesting at
+// 250: exhausting the goroutine stack kills the process with a Go traceback,
+// which is not a diagnostic anybody can act on. It is far above any depth a
+// sensible program reaches and far below where the 1 GB stack ceiling is in
+// sight.
+const maxCallDepth = 3000
+
+// A frame is one active call.
+type frame struct {
+	// file is where the callee's body was written.
+	file *source.File
+	// span locates the call site, in the caller's file.
+	span source.Span
 }
 
 // New returns an interpreter writing to stdout and stderr.
@@ -159,7 +185,24 @@ func (i *Interp) Run(prog *ast.Program) (result value.Value, err error) {
 // sentinel is what keeps one failure from producing a cascade of follow-on
 // messages describing the confusion it caused.
 func (i *Interp) fail(span source.Span, format string, args ...any) {
-	panic(&Error{Span: span, Msg: fmt.Sprintf(format, args...)})
+	i.failIn(i.curFile(), span, format, args...)
+}
+
+// failIn is fail for a span that belongs to a file other than the one being
+// evaluated — a call site, when the callee was written elsewhere.
+func (i *Interp) failIn(file *source.File, span source.Span, format string, args ...any) {
+	panic(&Error{File: file, Span: span, Msg: fmt.Sprintf(format, args...)})
+}
+
+// curFile is the file whose text the node being evaluated came from: the body
+// of the innermost active call, or the file being run at top level.
+func (i *Interp) curFile() *source.File {
+	if n := len(i.frames); n > 0 {
+		if f := i.frames[n-1].file; f != nil {
+			return f
+		}
+	}
+	return i.file
 }
 
 // ---------------------------------------------------------------------------
@@ -255,7 +298,7 @@ func (i *Interp) eval(n ast.Node, e *env) value.Value {
 		return i.evalFor(n, e)
 
 	case *ast.Function:
-		return &Function{Decl: n, Env: e}
+		return &Function{Decl: n, Env: e, File: i.curFile()}
 	case *ast.FunctionCall:
 		return i.evalCall(n, e)
 
@@ -1000,7 +1043,11 @@ func (i *Interp) convert(v value.Value, to string, span source.Span) value.Value
 // Report writes a runtime error in the same shape as a compile-time diagnostic,
 // so both look the same to whoever is reading the terminal.
 func (i *Interp) Report(err *Error) {
-	bag := diag.New(i.file)
+	file := err.File
+	if file == nil {
+		file = i.file
+	}
+	bag := diag.New(file)
 	bag.Errorf(err.Span, "%s", err.Msg)
 	fmt.Fprint(i.Err, bag.Render())
 }

--- a/internal/interp/interp_test.go
+++ b/internal/interp/interp_test.go
@@ -1,6 +1,7 @@
 package interp_test
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -892,5 +893,35 @@ func TestStdlibMath(t *testing.T) {
 		if got := withStdlib(t, test.src); got != test.want {
 			t.Errorf("%s: got %s, want %s", test.src, got, test.want)
 		}
+	}
+}
+
+// Recursion past maxCallDepth is an ordinary runtime error. Without the limit
+// it grew the goroutine stack to Go's 1 GB ceiling and killed the process.
+func TestRecursionIsBounded(t *testing.T) {
+	fails(t, `let f = func (n) do f(n + 1) end
+f(0)`, "call depth")
+}
+
+// A runtime error raised inside a standard library module is located in that
+// module's file, not in the file being run. The span is a byte offset into
+// <stdlib>, so rendering it against the user's file pointed at nothing.
+func TestRuntimeErrorCarriesItsOwnFile(t *testing.T) {
+	var out, errOut strings.Builder
+	_, err := interp.Eval("test.ari", `println(Dict.delete([:a => 1], :zz))`, interp.Options{
+		Out: &out, Err: &errOut, In: strings.NewReader(""),
+	})
+	if err == nil {
+		t.Fatal("expected a failure")
+	}
+	var re *interp.Error
+	if !errors.As(err, &re) {
+		t.Fatalf("expected an *interp.Error, got %T", err)
+	}
+	if re.File == nil {
+		t.Fatal("the error carries no file")
+	}
+	if !strings.HasPrefix(re.File.Name, "<stdlib>/") {
+		t.Errorf("error located in %q, want a <stdlib> module", re.File.Name)
 	}
 }

--- a/internal/interp/run.go
+++ b/internal/interp/run.go
@@ -261,7 +261,11 @@ func (s *Session) Eval(src string) (value.Value, error) {
 	if err != nil {
 		var re *Error
 		if errors.As(err, &re) {
-			b := diag.New(file)
+			at := re.File
+			if at == nil {
+				at = file
+			}
+			b := diag.New(at)
 			b.Errorf(re.Span, "%s", re.Msg)
 			return nil, fmt.Errorf("%s", strings.TrimRight(b.Render(), "\n"))
 		}

--- a/testdata/semantics/errors/_boom.ari
+++ b/testdata/semantics/errors/_boom.ari
@@ -1,0 +1,5 @@
+// Imported by import-runtime-error.ari. The fault is on line 2 of this file,
+// and that is where the diagnostic has to point.
+let boom = func () do
+  1 / 0
+end

--- a/testdata/semantics/errors/import-runtime-error.ari
+++ b/testdata/semantics/errors/import-runtime-error.ari
@@ -1,0 +1,6 @@
+// A runtime error raised inside an imported file is located in that file. The
+// span is a byte offset into the importee, so rendering it against the
+// importer drew an unrelated line of this file with a caret under nothing.
+import "_boom"
+println("before")
+boom()

--- a/testdata/semantics/errors/import-runtime-error.out
+++ b/testdata/semantics/errors/import-runtime-error.out
@@ -1,0 +1,5 @@
+before
+_boom.ari:4:3: error: division by zero
+    1 / 0
+    ^^^^^
+--- exit: 1

--- a/testdata/semantics/errors/recursion-limit.ari
+++ b/testdata/semantics/errors/recursion-limit.ari
@@ -1,0 +1,4 @@
+// Unbounded recursion is a diagnostic, not a Go traceback. The parser bounds
+// nesting for the same reason; this is the evaluator's half of it.
+let f = func (n) do f(n + 1) end
+f(0)

--- a/testdata/semantics/errors/recursion-limit.out
+++ b/testdata/semantics/errors/recursion-limit.out
@@ -1,0 +1,4 @@
+recursion-limit.ari:3:21: error: call depth of 3000 exceeded, probably infinite recursion
+  let f = func (n) do f(n + 1) end
+                      ^^^^^^^^
+--- exit: 1

--- a/testdata/semantics/errors/stdlib-runtime-error.ari
+++ b/testdata/semantics/errors/stdlib-runtime-error.ari
@@ -1,0 +1,4 @@
+// Every panic() in the standard library raises against a span in <stdlib>.
+// Rendered against this file the offset usually lands past the end of it, so
+// the reader got a line number that does not exist and no caret at all.
+println(Dict.delete([:a => 1], :zz))

--- a/testdata/semantics/errors/stdlib-runtime-error.out
+++ b/testdata/semantics/errors/stdlib-runtime-error.out
@@ -1,0 +1,4 @@
+<stdlib>/dict.ari:41:7: error: Dictionary key 'zz' doesn't exist
+        panic("Dictionary key '" + String(key) + "' doesn't exist")
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+--- exit: 1


### PR DESCRIPTION
A `source.Span` is a pair of byte offsets and means nothing without the file it came from, but `Interp.Report` rendered every span against the file being run. A program evaluates code from three files — its own, whatever it imports, and the standard library — so a fault in an imported file drew the importer's text at the importee's offsets, and a fault in the standard library landed past the end of the user's file and showed no source line at all. Fixing it needs a call-frame stack, which is also where the missing recursion limit can live.

## What changed

- `interp.Error` carries the `*source.File` its span indexes into; `Report` and `Session.Eval` render against it.
- `*Function` records the file its body was written in. `callFunction` pushes a frame naming that file, and `fail` locates errors in the innermost frame.
- Errors reported *at* a call — arity, parameter types, return type — go through a new `failIn` with the caller's file, since those are faults in the caller.
- Recursion past `maxCallDepth` (3000 frames) fails as an ordinary Aria diagnostic instead of exhausting the goroutine stack and dying with a Go traceback.
- Added `errors/import-runtime-error`, `errors/stdlib-runtime-error` and `errors/recursion-limit` to the characterization suite, plus two Go tests.
- Documented both rulings in `docs/architecture.md`.

All 128 existing goldens are byte-identical.

Closes #5