### PR TITLE
Reject stray control keywords, `_` out of position, and for-loop over-arity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ go test ./internal/parser/  -run=Fuzz -fuzz=FuzzParse -fuzztime=30s
 
 ## The characterization suite is the arbiter
 
-`testdata/semantics/` holds 132 `.ari` files, each with a `.out` golden recording exactly
+`testdata/semantics/` holds 137 `.ari` files, each with a `.out` golden recording exactly
 what the interpreter prints and what it exits with.
 
 **If a golden changes, you changed the language.** That is either the point of your change

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -151,6 +151,19 @@ exist, and `Enum.reduce` annotated its array parameter as `Function`.
 Parameters and loop variables bind like `let`. That matters for immutability below: a
 function that could rebind its parameter could mutate a collection its caller owns.
 
+**It also checks what only a tree walk can see.** Three mistakes are knowable before the
+program starts, and each was silent or late:
+
+- `break` and `continue` outside a loop, and `return` outside a function. `Interp.Run`
+  stops its node loop on any control signal, so a stray `break` at top level discarded the
+  rest of the file with no diagnostic and exit code `0`. A function body resets the loop
+  count, so a `break` inside a function that happens to be defined in a loop is an error
+  too — the call is not the loop's body.
+- `_` anywhere but a switch case value or an append target. It mapped to nil in `eval`, so
+  `let x = _` was accepted and quietly meant nothing.
+- More than two `for` loop variables. The evaluator checked this inside the per-iteration
+  closure, so `for a, b, c in []` never reached the check at all.
+
 The resolver records a slot index and scope depth for every binding. The evaluator does
 not use them yet — it walks a scope chain of name maps — but they are there for when
 lookup becomes worth optimising.
@@ -260,7 +273,7 @@ something the author of an Aria program can act on.
 
 ## The characterization suite
 
-`testdata/semantics/` holds 132 cases. Each `.ari` file has a `.out` golden recording
+`testdata/semantics/` holds 137 cases. Each `.ari` file has a `.out` golden recording
 exactly what the interpreter prints and what it exits with.
 
 ```bash

--- a/internal/interp/interp.go
+++ b/internal/interp/interp.go
@@ -665,6 +665,14 @@ func (i *Interp) loop(n *ast.For, e *env, items []item) value.Value {
 		}
 	}
 
+	// The resolver rejects more than two loop variables, so this is a backstop
+	// for the one path that never reaches the resolver: an imported file, which
+	// is parsed and evaluated but not resolved. It is checked once rather than
+	// per iteration, which is why `for a, b, c in []` used to be accepted.
+	if len(names) > 2 {
+		i.fail(n.Span(), "a for loop takes at most 2 variables, got %d", len(names))
+	}
+
 	run := func(it item) bool {
 		scope := newEnv(e)
 		switch len(names) {
@@ -674,8 +682,6 @@ func (i *Interp) loop(n *ast.For, e *env, items []item) value.Value {
 		case 2:
 			scope.define(names[0], it.key)
 			scope.define(names[1], it.val)
-		default:
-			i.fail(n.Span(), "a for loop takes at most 2 variables, got %d", len(names))
 		}
 
 		v := i.evalBlock(n.Body, scope)

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -997,6 +997,12 @@ func (p *Parser) parseFor() ast.Node {
 			})
 			p.advance()
 		}
+		// Widen the list to cover every name, not just the first: a diagnostic
+		// about the list as a whole — too many loop variables — should underline
+		// the whole list.
+		if len(args.Elements) > 0 {
+			args.Sp = span(args.Elements[0].Span(), args.Elements[len(args.Elements)-1].Span())
+		}
 		node.Arguments = args
 
 		if p.at(token.In) {

--- a/internal/resolver/corpus_test.go
+++ b/internal/resolver/corpus_test.go
@@ -97,6 +97,12 @@ var expectedResolveErrors = map[string]string{
 	"mutate-through-let.ari":   "3.4 writes through a let-bound collection",
 	"for-scope-leak.ari":       "3.3 reads a loop variable after the loop",
 	"undefined-module.ari":     "accesses a module that was never declared",
+
+	"toplevel-break.ari":           "breaks where no loop is running",
+	"toplevel-return.ari":          "returns from outside a function",
+	"break-inside-nested-func.ari": "breaks from a function nested in a loop",
+	"placeholder-as-value.ari":     "reads `_` where it means nothing",
+	"for-too-many-vars.ari":        "gives a for loop three variables",
 }
 
 // Three cases that USED to fail now resolve cleanly, which is the point:

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -150,6 +150,13 @@ type Resolver struct {
 	// hasImport suppresses undefined-name errors, since an import can bring in
 	// names this pass cannot see.
 	hasImport bool
+
+	// loops and funcs count the enclosing loop and function bodies, so that
+	// break, continue and return can be checked where they mean something. A
+	// function body resets loops: a `break` inside a function nested in a loop
+	// belongs to neither, and used to unwind out of the call.
+	loops int
+	funcs int
 }
 
 // New returns a Resolver with a global scope containing the builtins.
@@ -369,7 +376,16 @@ func (r *Resolver) node(n ast.Node) {
 	case *ast.Switch:
 		r.node(n.Control)
 		for _, c := range n.Cases {
-			r.node(c.Values)
+			// A case value may be `_`, the wildcard. Walk the elements rather
+			// than the list so the placeholder is not reported as one out of
+			// position.
+			if c.Values != nil {
+				for _, el := range c.Values.Elements {
+					if _, wild := el.(*ast.Placeholder); !wild {
+						r.node(el)
+					}
+				}
+			}
 			r.node(c.Body)
 		}
 		if n.Default != nil {
@@ -390,12 +406,34 @@ func (r *Resolver) node(n ast.Node) {
 	case *ast.ModuleAccess:
 		r.moduleAccess(n)
 
+	// A control keyword outside the construct it controls is knowable here,
+	// and silent otherwise: Interp.Run stops its node loop on any signal, so a
+	// stray `break` at top level discarded the rest of the file with no
+	// diagnostic and exit code 0.
+	case *ast.Break:
+		if r.loops == 0 {
+			r.diags.Errorf(n.Span(), "'break' outside a loop")
+		}
+	case *ast.Continue:
+		if r.loops == 0 {
+			r.diags.Errorf(n.Span(), "'continue' outside a loop")
+		}
 	case *ast.Return:
+		if r.funcs == 0 {
+			r.diags.Errorf(n.Span(), "'return' outside a function")
+		}
 		r.node(n.Value)
 
-	case *ast.Import, *ast.Break, *ast.Continue,
+	// `_` is meaningful in exactly two positions, a switch case value and an
+	// append target, and neither reaches here: both are skipped by the code
+	// that walks them. Anywhere else it evaluated to nil, so `let x = _` was
+	// accepted and quietly meant nothing.
+	case *ast.Placeholder:
+		r.diags.Errorf(n.Span(), "'_' is a placeholder: it means something only as a switch case value or an append target")
+
+	case *ast.Import,
 		*ast.Integer, *ast.Float, *ast.String, *ast.Atom,
-		*ast.Boolean, *ast.Nil, *ast.Placeholder:
+		*ast.Boolean, *ast.Nil:
 		// Nothing to resolve.
 	}
 }
@@ -437,7 +475,11 @@ func (r *Resolver) assign(n *ast.Assign) {
 			break
 		}
 		subscript = true
-		r.node(sub.Index)
+		// `a[] = v` and `a[_] = v` both parse to a placeholder index. On the
+		// left of an assignment that is the append target, not a stray `_`.
+		if _, appendTarget := sub.Index.(*ast.Placeholder); !appendTarget {
+			r.node(sub.Index)
+		}
 		target = sub.Left
 	}
 
@@ -479,17 +521,26 @@ func (r *Resolver) forLoop(n *ast.For) {
 
 	r.push()
 	if n.Arguments != nil {
+		// The evaluator checked this per iteration, so an empty enumerable
+		// never reached it and `for a, b, c in []` was accepted. The count is
+		// right here, before anything runs.
+		if len(n.Arguments.Elements) > 2 {
+			r.diags.Errorf(n.Arguments.Span(), "a for loop takes at most 2 variables, got %d",
+				len(n.Arguments.Elements))
+		}
 		for _, id := range n.Arguments.Elements {
 			r.declare(id, KindLoop, false)
 		}
 	}
 	// The body's own Block would push a second scope; resolve its contents
 	// directly so loop variables and body names share one level.
+	r.loops++
 	if n.Body != nil {
 		for _, c := range n.Body.Nodes {
 			r.node(c)
 		}
 	}
+	r.loops--
 	r.pop(n)
 }
 
@@ -513,11 +564,18 @@ func (r *Resolver) function(n *ast.Function) {
 		// hole that immutable collections close.
 		r.declare(p.Name, KindParam, false)
 	}
+	// A `return` in here has something to return from, and a `break` does not
+	// reach a loop outside the call.
+	outerLoops := r.loops
+	r.loops = 0
+	r.funcs++
 	if n.Body != nil {
 		for _, c := range n.Body.Nodes {
 			r.node(c)
 		}
 	}
+	r.funcs--
+	r.loops = outerLoops
 	r.pop(n)
 }
 

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -364,3 +364,91 @@ func TestBadNodesAreSkipped(t *testing.T) {
 			bag.Len()-before, bag.Render())
 	}
 }
+
+// tryResolve parses and resolves src, reporting whether it parsed at all.
+func tryResolve(src string) (*diag.Bag, bool) {
+	file := source.NewFile("test.ari", []byte(src))
+	bag := diag.New(file)
+
+	prog := parser.New(file, bag).Parse()
+	if bag.HasErrors() {
+		return bag, false
+	}
+	New(file, bag).Resolve(prog)
+	return bag, true
+}
+
+// break, continue and return outside the construct they control are resolver
+// errors. Interp.Run stops its node loop on any signal, so a stray one at top
+// level used to discard the rest of the file with no diagnostic at all.
+func TestStrayControlKeywords(t *testing.T) {
+	for _, src := range []string{
+		"break",
+		"continue",
+		"return 1",
+		"for v in [1]\n  let f = func () do break end\nend",
+	} {
+		bag, ok := tryResolve(src)
+		if !ok {
+			t.Fatalf("%q did not parse", src)
+		}
+		if !bag.HasErrors() {
+			t.Errorf("%q resolved cleanly, expected a diagnostic", src)
+		}
+	}
+
+	// The legal placements stay legal.
+	for _, src := range []string{
+		"for v in [1]\n  break\nend",
+		"for v in [1]\n  continue\nend",
+		"let f = func () do return 1 end",
+	} {
+		bag, ok := tryResolve(src)
+		if !ok {
+			t.Fatalf("%q did not parse", src)
+		}
+		if bag.HasErrors() {
+			t.Errorf("%q was rejected:\n%s", src, bag.Render())
+		}
+	}
+}
+
+// `_` means something as a switch case value and as an append target, and
+// nothing anywhere else — where it used to evaluate to nil.
+func TestPlaceholderOutOfPosition(t *testing.T) {
+	for _, src := range []string{"let x = _", "println([1][_])", "let a = [_]"} {
+		bag, ok := tryResolve(src)
+		if !ok {
+			t.Fatalf("%q did not parse", src)
+		}
+		if !bag.HasErrors() {
+			t.Errorf("%q resolved cleanly, expected a diagnostic", src)
+		}
+	}
+
+	for _, src := range []string{
+		"var a = [1]\na[] = 2",
+		"var a = [1]\na[_] = 2",
+		"switch 1\ncase _ then 2\nend",
+	} {
+		bag, ok := tryResolve(src)
+		if !ok {
+			t.Fatalf("%q did not parse", src)
+		}
+		if bag.HasErrors() {
+			t.Errorf("%q was rejected:\n%s", src, bag.Render())
+		}
+	}
+}
+
+// The evaluator checked loop-variable arity once per iteration, so an empty
+// enumerable never reached the check.
+func TestForLoopVariableArity(t *testing.T) {
+	bag, ok := tryResolve("for a, b, c in []\n  println(a)\nend")
+	if !ok {
+		t.Fatal("did not parse")
+	}
+	if !bag.HasErrors() {
+		t.Error("three loop variables resolved cleanly, expected a diagnostic")
+	}
+}

--- a/testdata/semantics/control/break-inside-nested-func.ari
+++ b/testdata/semantics/control/break-inside-nested-func.ari
@@ -1,0 +1,7 @@
+// A `break` inside a function that happens to be defined in a loop belongs to
+// neither: the call is not the loop's body. It used to unwind out of the call
+// and quietly end the loop.
+for v in [1, 2, 3]
+  let f = func () do break end
+  f()
+end

--- a/testdata/semantics/control/break-inside-nested-func.out
+++ b/testdata/semantics/control/break-inside-nested-func.out
@@ -1,0 +1,4 @@
+break-inside-nested-func.ari:5:22: error: 'break' outside a loop
+    let f = func () do break end
+                       ^^^^^
+--- exit: 1

--- a/testdata/semantics/control/for-too-many-vars.ari
+++ b/testdata/semantics/control/for-too-many-vars.ari
@@ -1,0 +1,6 @@
+// The arity check lived inside the per-iteration closure, so an empty
+// enumerable never reached it and this ran to completion.
+for a, b, c in []
+  println(a)
+end
+println("survived")

--- a/testdata/semantics/control/for-too-many-vars.out
+++ b/testdata/semantics/control/for-too-many-vars.out
@@ -1,0 +1,4 @@
+for-too-many-vars.ari:3:5: error: a for loop takes at most 2 variables, got 3
+  for a, b, c in []
+      ^^^^^^^
+--- exit: 1

--- a/testdata/semantics/errors/placeholder-as-value.ari
+++ b/testdata/semantics/errors/placeholder-as-value.ari
@@ -1,0 +1,4 @@
+// `_` is meaningful as a switch case value and as an append target. Anywhere
+// else it evaluated to nil, so this was accepted and quietly meant nothing.
+let x = _
+println(x)

--- a/testdata/semantics/errors/placeholder-as-value.out
+++ b/testdata/semantics/errors/placeholder-as-value.out
@@ -1,0 +1,4 @@
+placeholder-as-value.ari:3:9: error: '_' is a placeholder: it means something only as a switch case value or an append target
+  let x = _
+          ^
+--- exit: 1

--- a/testdata/semantics/errors/toplevel-break.ari
+++ b/testdata/semantics/errors/toplevel-break.ari
@@ -1,0 +1,5 @@
+// Interp.Run stops its node loop on any control signal, so a `break` where no
+// loop is running discarded the rest of the file: no output, no diagnostic, and
+// exit code 0. Nothing downstream could tell anything had gone wrong.
+break
+println("after")

--- a/testdata/semantics/errors/toplevel-break.out
+++ b/testdata/semantics/errors/toplevel-break.out
@@ -1,0 +1,4 @@
+toplevel-break.ari:4:1: error: 'break' outside a loop
+  break
+  ^^^^^
+--- exit: 1

--- a/testdata/semantics/errors/toplevel-return.ari
+++ b/testdata/semantics/errors/toplevel-return.ari
@@ -1,0 +1,4 @@
+// The same shape as toplevel-break: a `return` outside a function truncated
+// the program silently.
+return 1
+println("after")

--- a/testdata/semantics/errors/toplevel-return.out
+++ b/testdata/semantics/errors/toplevel-return.out
@@ -1,0 +1,4 @@
+toplevel-return.ari:3:1: error: 'return' outside a function
+  return 1
+  ^^^^^^^^
+--- exit: 1


### PR DESCRIPTION
Three mistakes the resolver was in a position to catch and did not. All three walk a tree it already visits, and all three produced either silence or a runtime error for something knowable before the program starts — a `break` at top level discarded the rest of the file with no diagnostic and exit code `0`.

## What changed

- `break`/`continue` outside a loop and `return` outside a function are resolver errors. A function body resets the loop count, so a `break` inside a function defined in a loop is an error too — the call is not the loop's body.
- `_` is a resolver error anywhere but a switch case value or an append target. Both legal positions are skipped by the code that walks them.
- `for` with more than two loop variables is a resolver error, regardless of what it iterates. The runtime check survives, moved out of the per-iteration closure, as a backstop for imported files — which are evaluated but never resolved.
- The parser widens an `IdentifierList`'s span to cover every name, so the arity diagnostic underlines the whole list.
- Five characterization cases and three resolver tests added.

No existing golden changed.

Closes #6