### PR TITLE
Make integer arithmetic fail rather than wrap, and Float % 0.0 raise

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,13 +30,19 @@ scripts/               the suite's runner
 
 ```bash
 go build ./... && go vet ./... && gofmt -l . && go test ./...
+golangci-lint run ./...
 bash scripts/characterize.sh verify
 bash scripts/check-readme.sh
 ```
 
-The last one is the important one. `go test` covers the Go code; the characterization
-suite covers *the language*, and it is the thing that catches a change you did not intend
-to make.
+CI runs `golangci-lint` at a pinned version, and it checks things `go vet` does not —
+`ineffassign` and `predeclared` have both failed a branch that passed everything else.
+Install it with `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.1`
+to match.
+
+The characterization suite is the important one. `go test` covers the Go code; the suite
+covers *the language*, and it is the thing that catches a change you did not intend to
+make.
 
 After touching the scanner or parser, also run the fuzzers for 30 seconds each. They are
 cheap and they have both found real bugs:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ go test ./internal/parser/  -run=Fuzz -fuzz=FuzzParse -fuzztime=30s
 
 ## The characterization suite is the arbiter
 
-`testdata/semantics/` holds 139 `.ari` files, each with a `.out` golden recording exactly
+`testdata/semantics/` holds 143 `.ari` files, each with a `.out` golden recording exactly
 what the interpreter prints and what it exits with.
 
 **If a golden changes, you changed the language.** That is either the point of your change

--- a/README.md
+++ b/README.md
@@ -229,6 +229,14 @@ The operand *types* decide the result type, never the operand values. That's wha
 10 / 4.0 // 2.5
 ```
 
+Integer arithmetic never wraps. An `Int` is a 64-bit signed integer, and an operation whose result doesn't fit in one is an error rather than a plausible-looking negative number:
+
+```swift
+2 ** 62 // 4611686018427387904
+```
+
+Floats are IEEE 754 and are left as they are, so overflow there reaches `Inf`. Division and modulo by zero are errors on both.
+
 ### Float
 
 Floating point numbers are used in a very similar way to Integers. In fact, they can be mixed and matched, like `3 + 0.2` or `5.0 + 2`, where the result will always be a Float.
@@ -492,7 +500,7 @@ true == true
 false != true
 ```
 
-Bitwise and bitshift operator apply only to Integers. Float values can't be used, even those that "look" as Integers, like `1.0` or `5.0`.
+Bitwise and bitshift operator apply only to Integers. Float values can't be used, even those that "look" as Integers, like `1.0` or `5.0`. A shift count has to be between 0 and 63, and a left shift that would push bits past the sign bit is an error like any other overflow.
 
 ```swift
 10 >> 1

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -242,6 +242,31 @@ Real division needs a `Float` operand: `10 / 4.0`.
 visibly a `Float`: `1.5`, `3.0`, `1e-05`. The old `%f` turned `1.5` into `1.500000` and
 `1e-5` into `0.000010`, losing the value entirely.
 
+**Integer arithmetic fails rather than wraps.** `+`, `-`, `*`, `**`, `<<`, `/` and unary
+`-` raise a runtime error when the result does not fit in an `Int`, instead of silently
+landing on a wrapped value.
+
+Aria's `Int` is one fixed-width signed integer. There is no unsigned counterpart, no way to
+name the width, and no operator that means "wrap deliberately" — so a program has no way to
+observe or intend a wrap, and a wrapped result is simply a wrong answer that looks like a
+computed one. That is the failure mode this codebase keeps removing: a plausible value that
+surfaces a long way from its cause. The cost is one comparison per operation, which a
+tree-walking interpreter does not notice.
+
+`**` follows from the same rule as `/`: it is computed in integer arithmetic, by squaring.
+Routing it through `math.Pow` lost precision above 2^53 and then converted out of range,
+which on amd64 produced `MinInt64` — so `3 ** 40` was a negative number.
+
+**A shift count of 64 or more is an error**, rather than Go's answer of shifting every bit
+out and yielding `0`. `1 << 100` is not `0`; it is a question about a 64-bit integer that
+has no answer.
+
+**Floats follow IEEE 754** and are left alone: overflow reaches `Inf`, which is a value the
+format defines. The one exception is `Float % 0.0`, which returned `NaN` while `Int / 0`,
+`Int % 0` and `Float / 0.0` all raised. A `NaN` propagates through arithmetic and compares
+false against everything including itself, so it is the same "surfaces far from its cause"
+shape. It raises now, like its siblings.
+
 ## Strings index by rune
 
 `"héllo"[1]` is `é`. The old runtime was inconsistent about this: anything built on
@@ -299,7 +324,7 @@ something the author of an Aria program can act on.
 
 ## The characterization suite
 
-`testdata/semantics/` holds 139 cases. Each `.ari` file has a `.out` golden recording
+`testdata/semantics/` holds 143 cases. Each `.ari` file has a `.out` golden recording
 exactly what the interpreter prints and what it exits with.
 
 ```bash

--- a/internal/interp/interp.go
+++ b/internal/interp/interp.go
@@ -778,6 +778,12 @@ func (i *Interp) evalPrefix(n *ast.Prefix, e *env) value.Value {
 	case "-":
 		switch v := v.(type) {
 		case value.Int:
+			// MinInt64 has no positive counterpart; Go negates it back to
+			// itself, which is the same silent wrong answer as any other
+			// overflow.
+			if int64(v) == math.MinInt64 {
+				i.fail(n.Span(), "Int overflow: -(%d) does not fit in an Int", int64(v))
+			}
 			return -v
 		case value.Float:
 			return -v
@@ -860,27 +866,62 @@ func (i *Interp) evalInfix(n *ast.Infix, e *env) value.Value {
 // result TYPE depended on the runtime values and a declared `-> Int` could fail
 // for inputs the author never tried.
 func (i *Interp) intOp(op string, l, r value.Int, span source.Span) value.Value {
+	a, b := int64(l), int64(r)
+
+	// check turns an overflow-reporting result into a value or a diagnostic.
+	check := func(n int64, ok bool) value.Value {
+		if !ok {
+			i.overflow(op, a, b, span)
+		}
+		return value.Int(n)
+	}
+
 	switch op {
 	case "+":
-		return l + r
+		return check(addInt(a, b))
 	case "-":
-		return l - r
+		return check(subInt(a, b))
 	case "*":
-		return l * r
+		return check(mulInt(a, b))
 	case "/":
-		if r == 0 {
+		if b == 0 {
 			i.fail(span, "division by zero")
 		}
-		return l / r
+		// The one division that overflows: MinInt64 / -1 has no positive
+		// counterpart to land on, and Go wraps it back to MinInt64.
+		if a == math.MinInt64 && b == -1 {
+			i.overflow(op, a, b, span)
+		}
+		return value.Int(a / b)
 	case "%":
-		if r == 0 {
+		if b == 0 {
 			i.fail(span, "division by zero")
 		}
-		return l % r
+		if a == math.MinInt64 && b == -1 {
+			return value.Int(0)
+		}
+		return value.Int(a % b)
 	case "**":
 		// Int ** Int stays an Int, so a negative exponent truncates to 0 the
-		// same way 1 / 2 does.
-		return value.Int(int64(math.Pow(float64(l), float64(r))))
+		// same way 1 / 2 does. It is computed in integer arithmetic: routed
+		// through float64 it lost precision above 2^53 and then converted out
+		// of range, which on amd64 produced MinInt64 — a plausible-looking
+		// negative number with nothing attached to say it was wrong.
+		if b < 0 {
+			switch a {
+			case 0:
+				i.fail(span, "division by zero")
+			case 1:
+				return value.Int(1)
+			case -1:
+				if b%2 == 0 {
+					return value.Int(1)
+				}
+				return value.Int(-1)
+			}
+			return value.Int(0)
+		}
+		return check(powInt(a, b))
 	case "<":
 		return value.Of(l < r)
 	case "<=":
@@ -894,15 +935,23 @@ func (i *Interp) intOp(op string, l, r value.Int, span source.Span) value.Value 
 	case "|":
 		return l | r
 	case "<<", ">>":
-		if l < 0 || r < 0 {
+		if a < 0 || b < 0 {
 			i.fail(span, "bitwise shift needs two non-negative Ints")
 		}
-		if op == "<<" {
-			return value.Int(uint64(l) << uint64(r))
+		// Go shifts a count of 64 or more all the way out, so `1 << 100` was
+		// 0 — an answer that looks computed and is not.
+		if b >= 64 {
+			i.fail(span, "bitwise shift count must be less than 64, got %d", b)
 		}
-		return value.Int(uint64(l) >> uint64(r))
+		if op == ">>" {
+			return value.Int(a >> uint(b))
+		}
+		if shifted := a << uint(b); shifted>>uint(b) == a {
+			return value.Int(shifted)
+		}
+		i.overflow(op, a, b, span)
 	case "..":
-		return intRange(int64(l), int64(r))
+		return intRange(a, b)
 	}
 	i.fail(span, "unknown Int operator '%s'", op)
 	return value.NilValue
@@ -922,6 +971,13 @@ func (i *Interp) floatOp(op string, l, r value.Float, span source.Span) value.Va
 		}
 		return l / r
 	case "%":
+		// Every other divide-by-zero in the language is an error; falling
+		// through to math.Mod made this one a NaN, which then propagated
+		// through arithmetic and compared false against everything including
+		// itself, so the mistake surfaced a long way from its cause.
+		if r == 0 {
+			i.fail(span, "division by zero")
+		}
 		return value.Float(math.Mod(float64(l), float64(r)))
 	case "**":
 		return value.Float(math.Pow(float64(l), float64(r)))
@@ -999,6 +1055,71 @@ func (i *Interp) dictOp(op string, l, r *value.Dict, span source.Span) value.Val
 	}
 	i.fail(span, "unknown Dictionary operator '%s'", op)
 	return value.NilValue
+}
+
+func (i *Interp) overflow(op string, a, b int64, span source.Span) {
+	i.fail(span, "Int overflow: %d %s %d does not fit in an Int", a, op, b)
+}
+
+// addInt, subInt and mulInt report whether the result is representable.
+//
+// Aria's Int is one fixed-width signed integer with no unsigned counterpart and
+// no way for a program to observe or intend a wrap, so a wrapped result is a
+// wrong answer that looks like a computed one. See docs/architecture.md.
+func addInt(a, b int64) (int64, bool) {
+	s := a + b
+	if (a > 0 && b > 0 && s < 0) || (a < 0 && b < 0 && s >= 0) {
+		return 0, false
+	}
+	return s, true
+}
+
+func subInt(a, b int64) (int64, bool) {
+	d := a - b
+	if (b < 0 && d < a) || (b > 0 && d > a) {
+		return 0, false
+	}
+	return d, true
+}
+
+func mulInt(a, b int64) (int64, bool) {
+	if a == 0 || b == 0 {
+		return 0, true
+	}
+	// MinInt64 has no positive counterpart, so p/b == a cannot distinguish an
+	// overflow from a correct product where it is involved.
+	if a == math.MinInt64 || b == math.MinInt64 {
+		if a == 1 || b == 1 {
+			return a * b, true
+		}
+		return 0, false
+	}
+	p := a * b
+	if p/b != a {
+		return 0, false
+	}
+	return p, true
+}
+
+// powInt is exponentiation by squaring, exact within int64. exp must not be
+// negative; intOp handles that case before calling.
+func powInt(base, exp int64) (int64, bool) {
+	result, b, ok := int64(1), base, true
+	for exp > 0 {
+		if exp&1 == 1 {
+			if result, ok = mulInt(result, b); !ok {
+				return 0, false
+			}
+		}
+		exp >>= 1
+		if exp == 0 {
+			break // the last squaring is never used, and can overflow
+		}
+		if b, ok = mulInt(b, b); !ok {
+			return 0, false
+		}
+	}
+	return result, true
 }
 
 func intRange(from, to int64) value.Value {

--- a/internal/interp/interp.go
+++ b/internal/interp/interp.go
@@ -1104,20 +1104,24 @@ func mulInt(a, b int64) (int64, bool) {
 // powInt is exponentiation by squaring, exact within int64. exp must not be
 // negative; intOp handles that case before calling.
 func powInt(base, exp int64) (int64, bool) {
-	result, b, ok := int64(1), base, true
+	result, b := int64(1), base
 	for exp > 0 {
 		if exp&1 == 1 {
-			if result, ok = mulInt(result, b); !ok {
+			r, ok := mulInt(result, b)
+			if !ok {
 				return 0, false
 			}
+			result = r
 		}
 		exp >>= 1
 		if exp == 0 {
 			break // the last squaring is never used, and can overflow
 		}
-		if b, ok = mulInt(b, b); !ok {
+		sq, ok := mulInt(b, b)
+		if !ok {
 			return 0, false
 		}
+		b = sq
 	}
 	return result, true
 }

--- a/internal/interp/interp_test.go
+++ b/internal/interp/interp_test.go
@@ -965,15 +965,15 @@ println(d)`); got != "1\n1\n[:a => 1]\n" {
 // signed integer with no unsigned counterpart, so a program has no way to
 // observe or intend a wrap.
 func TestIntArithmeticFailsOnOverflow(t *testing.T) {
-	const max = "9223372036854775807"
-	const min = "-9223372036854775807 - 1"
+	const intMax = "9223372036854775807"
+	const intMin = "-9223372036854775807 - 1"
 
 	for _, src := range []string{
-		`println(` + max + ` + 1)`,
-		`println(` + max + ` * 2)`,
-		`println((` + min + `) - 1)`,
-		`println(-(` + min + `))`,
-		`println((` + min + `) / -1)`,
+		`println(` + intMax + ` + 1)`,
+		`println(` + intMax + ` * 2)`,
+		`println((` + intMin + `) - 1)`,
+		`println(-(` + intMin + `))`,
+		`println((` + intMin + `) / -1)`,
 		`println(3 ** 40)`,
 		`println(2 ** 63)`,
 		`println(1 << 63)`,
@@ -994,7 +994,7 @@ func TestIntArithmeticFailsOnOverflow(t *testing.T) {
 		{`println(2 ** -1)`, "0"},
 		{`println(1 ** -3)`, "1"},
 		{`println((-1) ** -3)`, "-1"},
-		{`println((` + min + `) % -1)`, "0"},
+		{`println((` + intMin + `) % -1)`, "0"},
 		{`println(1 << 62)`, "4611686018427387904"},
 	}
 	for _, test := range tests {

--- a/internal/interp/interp_test.go
+++ b/internal/interp/interp_test.go
@@ -960,3 +960,53 @@ println(d)`); got != "1\n1\n[:a => 1]\n" {
 		t.Errorf("got %q", got)
 	}
 }
+
+// Integer arithmetic fails rather than wrapping: Aria's Int is one fixed-width
+// signed integer with no unsigned counterpart, so a program has no way to
+// observe or intend a wrap.
+func TestIntArithmeticFailsOnOverflow(t *testing.T) {
+	const max = "9223372036854775807"
+	const min = "-9223372036854775807 - 1"
+
+	for _, src := range []string{
+		`println(` + max + ` + 1)`,
+		`println(` + max + ` * 2)`,
+		`println((` + min + `) - 1)`,
+		`println(-(` + min + `))`,
+		`println((` + min + `) / -1)`,
+		`println(3 ** 40)`,
+		`println(2 ** 63)`,
+		`println(1 << 63)`,
+	} {
+		fails(t, src, "Int overflow")
+	}
+
+	// A shift count of 64 or more has no answer; Go's is 0.
+	fails(t, `println(1 << 100)`, "shift count must be less than 64")
+
+	// Everything that does fit is exact, including the powers that used to
+	// round through float64.
+	tests := []struct{ src, want string }{
+		{`println(2 ** 62)`, "4611686018427387904"},
+		{`println(10 ** 18)`, "1000000000000000000"},
+		{`println((-2) ** 3)`, "-8"},
+		{`println(0 ** 0)`, "1"},
+		{`println(2 ** -1)`, "0"},
+		{`println(1 ** -3)`, "1"},
+		{`println((-1) ** -3)`, "-1"},
+		{`println((` + min + `) % -1)`, "0"},
+		{`println(1 << 62)`, "4611686018427387904"},
+	}
+	for _, test := range tests {
+		if got := output(t, test.src); got != test.want+"\n" {
+			t.Errorf("%s: got %q, want %q", test.src, got, test.want)
+		}
+	}
+}
+
+// Float % 0.0 fell through to math.Mod and returned NaN while every sibling
+// divide-by-zero raised.
+func TestFloatModuloByZeroFails(t *testing.T) {
+	fails(t, `println(5.0 % 0.0)`, "division by zero")
+	fails(t, `println(0 ** -1)`, "division by zero")
+}

--- a/testdata/semantics/operators/float-modulo-zero.ari
+++ b/testdata/semantics/operators/float-modulo-zero.ari
@@ -1,0 +1,6 @@
+// Int / 0, Int % 0 and Float / 0.0 all error. Float % 0.0 fell through to
+// math.Mod and returned NaN, which propagates through arithmetic and compares
+// false against everything including itself, so the mistake surfaced a long
+// way from its cause.
+println(5.0 % 2.0)
+println(5.0 % 0.0)

--- a/testdata/semantics/operators/float-modulo-zero.out
+++ b/testdata/semantics/operators/float-modulo-zero.out
@@ -1,0 +1,5 @@
+1.0
+float-modulo-zero.ari:6:9: error: division by zero
+  println(5.0 % 0.0)
+          ^^^^^^^^^
+--- exit: 1

--- a/testdata/semantics/operators/int-overflow.ari
+++ b/testdata/semantics/operators/int-overflow.ari
@@ -1,0 +1,6 @@
+// Integer arithmetic fails rather than wrapping. Aria's Int is one fixed-width
+// signed integer with no unsigned counterpart, so a program has no way to
+// observe or intend a wrap: a wrapped result is a wrong answer that looks like
+// a computed one.
+println(9223372036854775807 - 1)
+println(9223372036854775807 + 1)

--- a/testdata/semantics/operators/int-overflow.out
+++ b/testdata/semantics/operators/int-overflow.out
@@ -1,0 +1,5 @@
+9223372036854775806
+int-overflow.ari:6:9: error: Int overflow: 9223372036854775807 + 1 does not fit in an Int
+  println(9223372036854775807 + 1)
+          ^^^^^^^^^^^^^^^^^^^^^^^
+--- exit: 1

--- a/testdata/semantics/operators/power-overflow.ari
+++ b/testdata/semantics/operators/power-overflow.ari
@@ -1,0 +1,11 @@
+// `**` was math.Pow through float64: above 2^53 the float lost precision, and
+// past int64's range the conversion was undefined — on amd64 it landed on
+// MinInt64, a plausible-looking negative number with nothing attached to say it
+// was wrong. 3 ** 40 is 12157665459056928801, which does not fit.
+println(2 ** 10)
+println(10 ** 18)
+println(2 ** 62)
+println(2 ** -1)
+println(0 ** 0)
+println((-2) ** 3)
+println(3 ** 40)

--- a/testdata/semantics/operators/power-overflow.out
+++ b/testdata/semantics/operators/power-overflow.out
@@ -1,0 +1,10 @@
+1024
+1000000000000000000
+4611686018427387904
+0
+1
+-8
+power-overflow.ari:11:9: error: Int overflow: 3 ** 40 does not fit in an Int
+  println(3 ** 40)
+          ^^^^^^^
+--- exit: 1

--- a/testdata/semantics/operators/shift-out-of-range.ari
+++ b/testdata/semantics/operators/shift-out-of-range.ari
@@ -1,0 +1,7 @@
+// Go shifts a count of 64 or more all the way out, so `1 << 100` was 0 — an
+// answer that looks computed and is not. A left shift that pushes bits past the
+// sign bit is the same silent wrap as any other overflow.
+println(1 << 4)
+println(255 >> 4)
+println(1 << 62)
+println(1 << 100)

--- a/testdata/semantics/operators/shift-out-of-range.out
+++ b/testdata/semantics/operators/shift-out-of-range.out
@@ -1,0 +1,7 @@
+16
+15
+4611686018427387904
+shift-out-of-range.ari:7:9: error: bitwise shift count must be less than 64, got 100
+  println(1 << 100)
+          ^^^^^^^^
+--- exit: 1


### PR DESCRIPTION
The question underneath this issue was whether Aria's integer arithmetic wraps, saturates or fails, since the answer decides how much of the rest is a bug. It fails: an Aria `Int` is one fixed-width signed integer with no unsigned counterpart, no way to name the width, and no operator meaning "wrap deliberately" — so a program cannot observe or intend a wrap, and a wrapped result is a wrong answer that looks computed.

## What changed

- `+`, `-`, `*`, `**`, `<<`, `/` and unary `-` raise a runtime error when the result does not fit in an `Int`.
- `Int ** Int` is exponentiation by squaring, exact within int64 range. Through `math.Pow` it lost precision above 2^53 and then converted out of range, so `3 ** 40` was a negative number. Negative exponents still truncate to `0` the way `1 / 2` does; `0 ** -1` raises as the division by zero it is.
- A shift count of 64 or more raises instead of shifting every bit out and yielding `0`.
- `Float % 0.0` raises like `Int / 0`, `Int % 0` and `Float / 0.0`. It returned `NaN`, which propagates through arithmetic and compares false against everything including itself.
- Floats are otherwise left alone: overflow reaches `Inf`, which IEEE 754 defines.
- Policy recorded in `docs/architecture.md` next to the division rule it follows from, and in the README.
- Four cases added: `operators/power-overflow`, `operators/float-modulo-zero`, `operators/shift-out-of-range`, `operators/int-overflow`, plus a Go test covering the full matrix.

No existing golden changed.

Closes #7