### PR TITLE
Hoist top-level functions, so two of them can call each other

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ go test ./internal/parser/  -run=Fuzz -fuzz=FuzzParse -fuzztime=30s
 
 ## The characterization suite is the arbiter
 
-`testdata/semantics/` holds 153 `.ari` files, each with a `.out` golden recording exactly
+`testdata/semantics/` holds 157 `.ari` files, each with a `.out` golden recording exactly
 what the interpreter prints and what it exits with.
 
 **If a golden changes, you changed the language.** That is either the point of your change

--- a/README.md
+++ b/README.md
@@ -1030,7 +1030,23 @@ let background = Color.white
 let font_color = Color.hexToRGB(Color.grey)
 ```
 
-Because modules are interpreted and cached before-hand, properties and functions have access to each other. In contrast to modules, everything else in Aria is single pass and as such, it will only recognize calls to a module that has already been declared.
+Because modules are interpreted and cached before-hand, properties and functions have access to each other. Top-level functions hoist for the same reason, so two of them can call each other without one having to be wrapped in a module:
+
+```swift
+let isEven = func (n) do
+  if n == 0 then return true end
+  isOdd(n - 1)
+end
+
+let isOdd = func (n) do
+  if n == 0 then return false end
+  isEven(n - 1)
+end
+
+println(isEven(10)) // true
+```
+
+Everything else is single pass: only a `let` at the top level whose value is a function literal hoists, and a name has to be declared before it is read.
 
 A module is an ordinary value, so its name can be bound, passed to a function and returned from one:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -151,6 +151,25 @@ exist, and `Enum.reduce` annotated its array parameter as `Function`.
 Parameters and loop variables bind like `let`. That matters for immutability below: a
 function that could rebind its parameter could mutate a collection its caller owns.
 
+**Top-level functions hoist.** Every top-level `let` whose value is a function literal is
+declared before anything is resolved, so two functions that call each other can both live
+at the top level. Wrapping them in a module was the only way to write that, which is a
+strange thing to have to do for two free functions.
+
+The line is deliberate on both sides.
+
+*Only function literals.* A hoisted name is in scope during its own initializer by
+construction, which would defeat the `pending` check that catches `let x = x`. A function
+literal is the one value that can be built without evaluating anything first, so hoisting
+it early builds the same value — anything else would mean hoisting whatever has to run to
+produce it.
+
+*Only the top level.* A function body opens a scope of its own, and nothing in it hoists.
+
+The evaluator hoists to match, in `Interp.Run` and again for an imported file. Hoisting in
+only one of the two would let a name resolve and then not be there at runtime — `eval`'s
+Identifier case, the one whose comment says the two passes cannot disagree.
+
 **It also checks what only a tree walk can see.** Three mistakes are knowable before the
 program starts, and each was silent or late:
 
@@ -373,7 +392,7 @@ something the author of an Aria program can act on.
 
 ## The characterization suite
 
-`testdata/semantics/` holds 153 cases. Each `.ari` file has a `.out` golden recording
+`testdata/semantics/` holds 157 cases. Each `.ari` file has a `.out` golden recording
 exactly what the interpreter prints and what it exits with.
 
 ```bash

--- a/internal/interp/interp.go
+++ b/internal/interp/interp.go
@@ -171,6 +171,8 @@ func (i *Interp) Run(prog *ast.Program) (result value.Value, err error) {
 		}
 	}()
 
+	i.hoistFunctions(prog.Nodes, i.globals)
+
 	result = value.Value(value.NilValue)
 	for _, n := range prog.Nodes {
 		result = i.eval(n, i.globals)
@@ -179,6 +181,29 @@ func (i *Interp) Run(prog *ast.Program) (result value.Value, err error) {
 		}
 	}
 	return result, nil
+}
+
+// hoistFunctions binds every top-level function-valued `let` before the first
+// node runs, matching what the resolver hoists.
+//
+// Both halves are needed. Hoisting only in the resolver would let a name resolve
+// and then not be there — eval's Identifier case, the one whose comment says the
+// two passes cannot disagree. A function literal is the one value that can be
+// hoisted: it closes over the scope it is written in and needs nothing evaluated
+// first, so building it early is building the same value.
+func (i *Interp) hoistFunctions(nodes []ast.Node, e *env) {
+	file := i.curFile()
+	for _, n := range nodes {
+		let, ok := n.(*ast.Let)
+		if !ok || let.Name == nil {
+			continue
+		}
+		fn, isFunc := let.Value.(*ast.Function)
+		if !isFunc {
+			continue
+		}
+		e.define(let.Name.Value, &Function{Decl: fn, Env: e, File: file})
+	}
 }
 
 // fail stops evaluation with a runtime error. Unwinding rather than returning a
@@ -776,6 +801,7 @@ func (i *Interp) evalImport(n *ast.Import, e *env) value.Value {
 		globals: e, modules: i.modules,
 		dir: filepath.Dir(path), imported: i.imported,
 	}
+	sub.hoistFunctions(prog.Nodes, e)
 	for _, node := range prog.Nodes {
 		sub.eval(node, e)
 	}

--- a/internal/interp/interp_test.go
+++ b/internal/interp/interp_test.go
@@ -1160,3 +1160,44 @@ end`); got != "[1, \"b\", \"c\"]\n[2, \"b\", \"c\"]\n" {
 		t.Errorf("got %q", got)
 	}
 }
+
+// Top-level `let` did not hoist, so two functions that call each other could not
+// both live at the top level. Wrapping both in a module was the workaround.
+func TestTopLevelFunctionsHoist(t *testing.T) {
+	src := `let isEven = func (n) do
+  if n == 0 then return true end
+  isOdd(n - 1)
+end
+
+let isOdd = func (n) do
+  if n == 0 then return false end
+  isEven(n - 1)
+end
+
+println(isEven(10))
+println(isOdd(10))`
+	if got := output(t, src); got != "true\nfalse\n" {
+		t.Errorf("got %q", got)
+	}
+
+	// The evaluator hoists to match, so the name is bound before its own `let`
+	// has run rather than resolving to something that is not there.
+	if got := output(t, `println(later())
+let later = func () do "hoisted" end`); got != "hoisted\n" {
+		t.Errorf("got %q", got)
+	}
+}
+
+// The line is deliberate on both sides: only function literals, only the top
+// level.
+func TestHoistingIsNarrow(t *testing.T) {
+	fails(t, `let x = x`, "used in its own definition")
+	fails(t, `let f = func () do config end
+let config = 42`, "'config' is not defined")
+	fails(t, `let outer = func () do
+  let a = func () do b() end
+  let b = func () do 5 end
+end`, "'b' is not defined")
+	fails(t, `let f = func () do 1 end
+let f = func () do 2 end`, "already declared")
+}

--- a/internal/resolver/corpus_test.go
+++ b/internal/resolver/corpus_test.go
@@ -104,6 +104,9 @@ var expectedResolveErrors = map[string]string{
 	"placeholder-as-value.ari":       "reads `_` where it means nothing",
 	"for-too-many-vars.ari":          "gives a for loop three variables",
 	"pipe-placeholder-duplicate.ari": "marks two slots for one piped value",
+	"self-referential-let.ari":       "reads a name inside its own initializer",
+	"hoisting-not-for-values.ari":    "reads a non-function `let` before it is declared",
+	"hoisting-limits.ari":            "calls a later function from inside a function body",
 }
 
 // Three cases that USED to fail now resolve cleanly, which is the point:

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -156,6 +156,11 @@ type Resolver struct {
 	// names this pass cannot see.
 	hasImport bool
 
+	// hoisted holds top-level function bindings declared before their `let` was
+	// reached, so binding knows to fill one in rather than report it as a
+	// redeclaration.
+	hoisted map[*Binding]bool
+
 	// loops and funcs count the enclosing loop and function bodies, so that
 	// break, continue and return can be checked where they mean something. A
 	// function body resets loops: a `break` inside a function nested in a loop
@@ -175,6 +180,7 @@ func New(file *source.File, diags *diag.Bag) *Resolver {
 			sizes: map[ast.Node]int{},
 		},
 		modules: map[string]bool{},
+		hoisted: map[*Binding]bool{},
 	}
 	r.current = newScope(nil)
 	for _, name := range Builtins {
@@ -209,6 +215,7 @@ func (r *Resolver) predeclare(name string, kind Kind) {
 func (r *Resolver) Resolve(prog *ast.Program) *Info {
 	// Modules are hoisted, so collect their names before resolving anything.
 	r.collectModules(prog.Nodes)
+	r.hoistFunctions(prog.Nodes)
 
 	for _, n := range prog.Nodes {
 		r.node(n)
@@ -233,6 +240,37 @@ func (r *Resolver) collectModules(nodes []ast.Node) {
 			}
 		case *ast.Import:
 			r.hasImport = true
+		}
+	}
+}
+
+// hoistFunctions declares every top-level function-valued `let` before anything
+// is resolved, so two functions that call each other can both live at the top
+// level. Wrapping them in a module was the only way to write that, which is a
+// strange thing to have to do for two free functions.
+//
+// Only the top level, and only `let` whose value is a function literal. A
+// hoisted name is in scope during its own initializer by construction, so
+// hoisting anything else would defeat the `pending` check that catches
+// `let x = x`; and a function value is the one case the evaluator can hoist to
+// match, since a function literal needs nothing evaluated first.
+func (r *Resolver) hoistFunctions(nodes []ast.Node) {
+	for _, n := range nodes {
+		let, ok := n.(*ast.Let)
+		if !ok || let.Name == nil {
+			continue
+		}
+		if _, isFunc := let.Value.(*ast.Function); !isFunc {
+			continue
+		}
+		// Already taken — by a module, a builtin, or an earlier `let` of the
+		// same name. Leave it to binding, which reports the collision where the
+		// second declaration is written.
+		if _, taken := r.current.names[let.Name.Value]; taken {
+			continue
+		}
+		if b := r.declare(let.Name, KindLet, false); b != nil {
+			r.hoisted[b] = true
 		}
 	}
 }
@@ -496,7 +534,15 @@ func (r *Resolver) binding(name *ast.Identifier, value ast.Node, kind Kind, muta
 	// Marking it pending meanwhile catches the case that cannot mean anything,
 	// `let x = x`. The pending check looks only at the innermost scope, and a
 	// function body opens a new one, so the two do not conflict.
-	r.declare(name, kind, mutable)
+	// A hoisted name is already declared. Claim it rather than declaring it
+	// again, which would report the hoist as a redeclaration of itself; a
+	// second `let` of the same name finds it unclaimed and is reported.
+	if b, ok := r.current.names[name.Value]; ok && r.hoisted[b] {
+		delete(r.hoisted, b)
+		r.info.decls[name] = b
+	} else {
+		r.declare(name, kind, mutable)
+	}
 
 	r.current.pending[name.Value] = true
 	r.node(value)

--- a/testdata/semantics/errors/hoisting-not-for-values.ari
+++ b/testdata/semantics/errors/hoisting-not-for-values.ari
@@ -1,0 +1,6 @@
+// A non-function `let` does not hoist, so reading one before it is declared is
+// still an undefined name. Hoisting a value would mean hoisting whatever has to
+// be evaluated to produce it.
+let f = func () do config end
+let config = 42
+println(f())

--- a/testdata/semantics/errors/hoisting-not-for-values.out
+++ b/testdata/semantics/errors/hoisting-not-for-values.out
@@ -1,0 +1,4 @@
+hoisting-not-for-values.ari:4:20: error: 'config' is not defined
+  let f = func () do config end
+                     ^^^^^^
+--- exit: 1

--- a/testdata/semantics/errors/self-referential-let.ari
+++ b/testdata/semantics/errors/self-referential-let.ari
@@ -1,0 +1,5 @@
+// A name read inside its own initializer, in the same scope, cannot mean
+// anything. Hoisting is restricted to function literals so that this still
+// holds: a hoisted name is in scope during its own initializer by construction.
+let x = x
+println(x)

--- a/testdata/semantics/errors/self-referential-let.out
+++ b/testdata/semantics/errors/self-referential-let.out
@@ -1,0 +1,4 @@
+self-referential-let.ari:4:9: error: 'x' is used in its own definition
+  let x = x
+          ^
+--- exit: 1

--- a/testdata/semantics/functions/hoisting-limits.ari
+++ b/testdata/semantics/functions/hoisting-limits.ari
@@ -1,0 +1,8 @@
+// Only the top level, and only `let` whose value is a function literal. A
+// function body opens a scope of its own, and nothing in it hoists.
+let outer = func () do
+  let a = func () do b() end
+  let b = func () do 5 end
+  a()
+end
+println(outer())

--- a/testdata/semantics/functions/hoisting-limits.out
+++ b/testdata/semantics/functions/hoisting-limits.out
@@ -1,0 +1,4 @@
+hoisting-limits.ari:4:22: error: 'b' is not defined
+    let a = func () do b() end
+                       ^
+--- exit: 1

--- a/testdata/semantics/functions/mutual-recursion.ari
+++ b/testdata/semantics/functions/mutual-recursion.ari
@@ -1,0 +1,20 @@
+// Top-level `let` did not hoist, so two functions that call each other could not
+// both live at the top level: the first one's body named a function the resolver
+// had not seen yet. Wrapping both in a module was the only way to write it.
+let isEven = func (n) do
+  if n == 0 then return true end
+  isOdd(n - 1)
+end
+
+let isOdd = func (n) do
+  if n == 0 then return false end
+  isEven(n - 1)
+end
+
+println(isEven(10))
+println(isOdd(10))
+
+// The evaluator hoists to match, so a hoisted function is callable before its
+// own `let` has run rather than resolving to a name that is not there yet.
+println(later())
+let later = func () do "hoisted" end

--- a/testdata/semantics/functions/mutual-recursion.out
+++ b/testdata/semantics/functions/mutual-recursion.out
@@ -1,0 +1,4 @@
+true
+false
+hoisted
+--- exit: 0


### PR DESCRIPTION
Module bodies hoist their members, but top-level `let` did not — so two functions that call each other could not both live at the top level, and wrapping them in a module was the only way to write it. The machinery was already there in `resolver.module`; what needed deciding was where the line goes, since hoisting changes when a name becomes visible.

## What changed

- Every top-level `let` whose value is a function literal is declared before anything is resolved.
- The evaluator hoists to match, in `Interp.Run` and for imported files. Hoisting in only one pass would let a name resolve and then not be there at runtime.
- The line is deliberate on both sides. **Only function literals**: a hoisted name is in scope during its own initializer, which would defeat the `pending` check behind `let x = x`, and a function literal is the one value that can be built without evaluating anything first. **Only the top level**: a function body opens a scope of its own and nothing in it hoists.
- `functions/mutual-recursion`, `functions/hoisting-limits`, `errors/self-referential-let` and `errors/hoisting-not-for-values` record the feature and both edges, plus Go tests.
- Recorded in `docs/architecture.md`; the README's "everything else is single pass" sentence is corrected rather than deleted — it still is, apart from this.

No existing golden changed.

Closes #16