### PR TITLE
String interpolation, and a variadic println

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ go test ./internal/parser/  -run=Fuzz -fuzz=FuzzParse -fuzztime=30s
 
 ## The characterization suite is the arbiter
 
-`testdata/semantics/` holds 168 `.ari` files, each with a `.out` golden recording exactly
+`testdata/semantics/` holds 170 `.ari` files, each with a `.out` golden recording exactly
 what the interpreter prints and what it exits with.
 
 **If a golden changes, you changed the language.** That is either the point of your change

--- a/README.md
+++ b/README.md
@@ -176,7 +176,23 @@ println("\x41")      // "A"
 println("\u{1F600}") // an emoji, one character long
 ```
 
-Backticks make a raw string. It spans lines and processes no escapes, which is what you want for a block of text or a regex:
+Strings interpolate with `#{}`. A hole holds a whole expression, and the value is rendered the way `println` renders it:
+
+```swift
+let name = "Ada"
+let items = 3
+println("user #{name} has #{items} items")
+```
+
+A `#` is only special before a `{`, and `\#` opts out.
+
+`println` and `print` also take any number of arguments, joined with a space:
+
+```swift
+println("count:", 3)
+```
+
+Backticks make a raw string. It spans lines and processes no escapes — interpolation included — which is what you want for a block of text or a regex:
 
 ```swift
 let block = `line one

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -385,6 +385,23 @@ than one line, and every backslash in a regex passed to `String.match?` had to b
 Carriage returns are dropped from a raw literal, as Go does, so the same source means the
 same string on a checkout with CRLF line endings.
 
+`"..."` also interpolates: `#{expr}` holds a whole expression, and the value renders the
+way `println` renders it — `String`, not `Inspect` — so `"#{[1, 2]}"` is `[1, 2]` and a
+string in a hole does not come out quoted. `#` is only special before a `{`, and `\#` opts
+out. A raw literal processes nothing, interpolation included.
+
+The scanner hands an interpolated literal over as pieces — `StringStart`, the hole's own
+tokens, `StringPart`..., `StringEnd` — so the expressions parse with the grammar the
+parser already has and their spans point at where they are written, which is what a
+diagnostic inside a hole needs. Aria has no other use for braces, so a `}` while an
+interpolation is open always closes it; nesting needs a counter and nothing more.
+
+It lands in the tree as `ast.Interpolation` rather than desugaring to `+` with `String(...)`
+calls around each hole. Two reasons: `+` does not coerce and the `String` conversion
+refuses a collection, so a desugaring would make `"#{[1, 2]}"` an error where `println`
+prints it; and naming `String` in a desugaring means anything shadowing that name silently
+changes what every interpolated string in scope does.
+
 `\xNN`, `\uNNNN` and `\u{N...}` write a rune by codepoint, which for a language that
 indexes strings by rune was a conspicuous thing to be missing. **`\xNN` is a codepoint, not
 a byte**, even though two hex digits can only reach 0xFF: Aria strings are UTF-8 and index
@@ -449,7 +466,7 @@ something the author of an Aria program can act on.
 
 ## The characterization suite
 
-`testdata/semantics/` holds 168 cases. Each `.ari` file has a `.out` golden recording
+`testdata/semantics/` holds 170 cases. Each `.ari` file has a `.out` golden recording
 exactly what the interpreter prints and what it exits with.
 
 ```bash

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -122,6 +122,27 @@ type String struct {
 
 func (n *String) Inspect() string { return n.Text }
 
+// Interpolation is a string literal with #{...} holes, as an alternating list
+// of literal pieces and expressions.
+//
+// It is a node rather than a desugaring into `+` and String(...) calls for two
+// reasons. `+` does not coerce, and the String conversion refuses a collection,
+// so both would make `"#{[1, 2]}"` an error where println prints it; and a
+// desugaring that names String would mean anything shadowing that name silently
+// changes what every interpolated string in scope does.
+type Interpolation struct {
+	Base
+	Parts []Node
+}
+
+func (n *Interpolation) Inspect() string {
+	out := "\""
+	for _, p := range n.Parts {
+		out += p.Inspect()
+	}
+	return out + "\""
+}
+
 // Atom is a `:name` symbol.
 type Atom struct {
 	Base

--- a/internal/ast/walk.go
+++ b/internal/ast/walk.go
@@ -143,6 +143,11 @@ func Children(n Node) []Node {
 		node(n.Left)
 		ident(n.Name)
 
+	case *Interpolation:
+		for _, part := range n.Parts {
+			node(part)
+		}
+
 		// Leaves: Identifier, Integer, Float, String, Atom, Boolean, Nil,
 		// Placeholder, Break, Continue, Import, Bad, IdentifierList.
 	}

--- a/internal/interp/builtins.go
+++ b/internal/interp/builtins.go
@@ -20,19 +20,20 @@ func (i *Interp) installBuiltins() {
 		i.globals.define(name, &Builtin{Name: name, Fn: fn})
 	}
 
-	// println and print take exactly one argument, as they always have. The
-	// "expects exactly 1 argument" message that used to show up all over the
-	// goldens was the cascade from a failed expression yielding nil, not this
-	// check, so the arity is left alone.
+	// println and print take any number of arguments, joined with a space.
+	//
+	// The arity of one was left alone during the rewrite because the "expects
+	// exactly 1 argument" messages all over the goldens turned out to be a
+	// cascade from a failed expression yielding nil rather than from this
+	// check. That was a reason not to change it while chasing a different bug,
+	// not a reason for it to stay.
 	def("println", func(ip *Interp, args []value.Value, span source.Span) value.Value {
-		ip.wantArgs("println", args, 1, span)
-		fmt.Fprintln(ip.Out, args[0].String())
+		fmt.Fprintln(ip.Out, joinArgs(args))
 		return value.NilValue
 	})
 
 	def("print", func(ip *Interp, args []value.Value, span source.Span) value.Value {
-		ip.wantArgs("print", args, 1, span)
-		fmt.Fprint(ip.Out, args[0].String())
+		fmt.Fprint(ip.Out, joinArgs(args))
 		return value.NilValue
 	})
 
@@ -540,6 +541,15 @@ func clampRange(size, start, length int) (int, int) {
 		end = size
 	}
 	return start, end
+}
+
+// joinArgs renders arguments the way println shows them, separated by a space.
+func joinArgs(args []value.Value) string {
+	parts := make([]string, 0, len(args))
+	for _, a := range args {
+		parts = append(parts, a.String())
+	}
+	return strings.Join(parts, " ")
 }
 
 func (i *Interp) wantArgs(name string, args []value.Value, n int, span source.Span) {

--- a/internal/interp/interp.go
+++ b/internal/interp/interp.go
@@ -290,6 +290,16 @@ func (i *Interp) eval(n ast.Node, e *env) value.Value {
 	case *ast.As:
 		return i.convert(i.eval(n.Left, e), n.Right.Value, n.Span())
 
+	case *ast.Interpolation:
+		// Each piece renders the way println renders it, which is String and
+		// not Inspect: "#{[1, 2]}" is [1, 2], and a string in a hole does not
+		// come out quoted.
+		var b strings.Builder
+		for _, part := range n.Parts {
+			b.WriteString(i.eval(part, e).String())
+		}
+		return value.String(b.String())
+
 	case *ast.Array:
 		elems := make([]value.Value, 0, len(n.List.Elements))
 		for _, el := range n.List.Elements {

--- a/internal/interp/interp_test.go
+++ b/internal/interp/interp_test.go
@@ -1335,3 +1335,49 @@ func TestSmallSyntaxGaps(t *testing.T) {
 	fails(t, `println(1 as Dictionary)`, "cannot convert Int to Dictionary")
 	fails(t, `println([1] as Dictionary)`, "[key, value] pairs")
 }
+
+// Printing a message with a value in it used to be a chain of conversions.
+func TestStringInterpolation(t *testing.T) {
+	tests := []struct{ src, want string }{
+		{`let n = 3
+println("has #{n} items")`, "has 3 items"},
+		{`println("#{1 + 2}")`, "3"},
+		// A hole renders the way println renders it: String, not Inspect.
+		{`println("#{[1, 2]}")`, "[1, 2]"},
+		{`let s = "x"
+println("#{s}")`, "x"},
+		{`println("no holes")`, "no holes"},
+		// A string inside a hole may interpolate in turn.
+		{`let n = 3
+println("outer #{ "inner #{n}" } done")`, "outer inner 3 done"},
+		// `#` is only special before a `{`, and `\#` opts out.
+		{`println("hash # alone")`, "hash # alone"},
+		{`println("escaped \#{x}")`, "escaped #{x}"},
+		// A raw literal processes nothing, interpolation included.
+		{"println(`raw #{x}`)", "raw #{x}"},
+	}
+	for _, test := range tests {
+		if got := output(t, test.src); got != test.want+"\n" {
+			t.Errorf("%s: got %q, want %q", test.src, got, test.want)
+		}
+	}
+
+	// A name in a hole resolves like any other, and is reported where it is
+	// written rather than against a synthetic file.
+	fails(t, `println("#{nope}")`, "'nope' is not defined")
+}
+
+// println and print take any number of arguments, joined with a space.
+func TestPrintIsVariadic(t *testing.T) {
+	tests := []struct{ src, want string }{
+		{`println("count:", 3)`, "count: 3\n"},
+		{`println("a", "b", "c")`, "a b c\n"},
+		{`println()`, "\n"},
+		{`print("x", "y")`, "x y"},
+	}
+	for _, test := range tests {
+		if got := output(t, test.src); got != test.want {
+			t.Errorf("%s: got %q, want %q", test.src, got, test.want)
+		}
+	}
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -304,6 +304,8 @@ func (p *Parser) parsePrefix() ast.Node {
 		return p.parseFloat()
 	case token.String:
 		return p.parseString()
+	case token.StringStart:
+		return p.parseInterpolation()
 	case token.Bool:
 		return &ast.Boolean{Base: ast.Base{Sp: p.tok.Span}, Value: p.text(p.tok) == "true"}
 	case token.Nil:
@@ -517,6 +519,50 @@ func unescape(s string) string {
 		}
 	}
 	return b.String()
+}
+
+// parseInterpolation reads a string literal with `#{...}` holes. The cursor is
+// on the StringStart piece.
+//
+// The scanner hands the pieces over as ordinary tokens with the hole's own
+// tokens between them, so the expressions parse with the grammar the parser
+// already has and their spans point at where they are written — which is what a
+// diagnostic inside a hole needs.
+func (p *Parser) parseInterpolation() ast.Node {
+	start := p.tok.Span
+	parts := []ast.Node{p.stringPiece(1, 2)} // "...#{
+
+	for {
+		p.advance()
+		if p.at(token.EOF) {
+			return p.bad(span(start, p.tok.Span), "unterminated string interpolation")
+		}
+		parts = append(parts, p.parseExpr(lowest))
+		p.advance()
+
+		switch p.tok.Kind {
+		case token.StringPart:
+			parts = append(parts, p.stringPiece(1, 2)) // }...#{
+		case token.StringEnd:
+			parts = append(parts, p.stringPiece(1, 1)) // }..."
+			return &ast.Interpolation{Base: ast.Base{Sp: span(start, p.tok.Span)}, Parts: parts}
+		default:
+			return p.bad(span(start, p.tok.Span),
+				"expected the end of an interpolation, found %s", p.describe(p.tok))
+		}
+	}
+}
+
+// stringPiece turns the current string-piece token into a literal, trimming
+// head bytes from the front and tail from the back — the delimiters, which
+// differ per piece.
+func (p *Parser) stringPiece(head, tail int) ast.Node {
+	raw := p.text(p.tok)
+	inner := ""
+	if len(raw) >= head+tail {
+		inner = raw[head : len(raw)-tail]
+	}
+	return &ast.String{Base: ast.Base{Sp: p.tok.Span}, Value: unescape(inner), Text: inner}
 }
 
 // decodeHexEscape reads \xNN, \uNNNN or \u{N...} from the start of s, which

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -411,6 +411,10 @@ func (r *Resolver) node(n ast.Node) {
 		for _, c := range n.Elements {
 			r.node(c)
 		}
+	case *ast.Interpolation:
+		for _, part := range n.Parts {
+			r.node(part)
+		}
 	case *ast.Array:
 		r.node(n.List)
 	case *ast.Dictionary:

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -39,6 +39,12 @@ type Scanner struct {
 	ch   rune       // rune at off, or eof
 	off  source.Pos // offset of ch
 	next source.Pos // offset just past ch
+
+	// interp counts the string interpolations currently open. Aria has no other
+	// use for braces, so a `}` while one is open always closes it and resumes
+	// the string — no depth counting inside the hole is needed. It nests: an
+	// interpolation may hold a string that interpolates in turn.
+	interp int
 }
 
 // New returns a Scanner over file, reporting problems into diags.
@@ -139,6 +145,13 @@ func (s *Scanner) scanOne(start source.Pos) (token.Token, bool) {
 
 	case ch == '`':
 		return s.scanRawString(start), true
+
+	case ch == '}' && s.interp > 0:
+		// The end of an interpolation hole. Scanning resumes inside the string
+		// that opened it.
+		s.interp--
+		s.advance()
+		return s.scanStringFrom(start, true), true
 	}
 
 	return s.scanOperator(start)
@@ -386,6 +399,21 @@ func (s *Scanner) scanDigits(valid func(rune) bool) int {
 // knows whether it needs the text.
 func (s *Scanner) scanString(start source.Pos) token.Token {
 	s.advance() // opening quote
+	return s.scanStringFrom(start, false)
+}
+
+// scanStringFrom reads a string literal, or one piece of an interpolated one.
+//
+// It stops at the closing quote or at the next `#{`, whichever comes first, so
+// a literal with holes arrives as StringStart, the hole's own tokens, then
+// StringPart... and StringEnd. `resuming` says the cursor started just past a
+// `}` rather than just past the opening quote, which is the only thing that
+// distinguishes the two pairs of kinds.
+func (s *Scanner) scanStringFrom(start source.Pos, resuming bool) token.Token {
+	closing, opening := token.String, token.StringStart
+	if resuming {
+		closing, opening = token.StringEnd, token.StringPart
+	}
 
 	for {
 		switch s.ch {
@@ -397,13 +425,23 @@ func (s *Scanner) scanString(start source.Pos) token.Token {
 
 		case '"':
 			s.advance()
-			return s.token(token.String, start)
+			return s.token(closing, start)
+
+		case '#':
+			if s.peek() != '{' {
+				s.advance()
+				continue
+			}
+			s.advance() // #
+			s.advance() // {
+			s.interp++
+			return s.token(opening, start)
 
 		case '\\':
 			escStart := s.off
 			s.advance()
 			switch s.ch {
-			case 'n', 't', 'r', 'a', 'b', 'f', 'v', '\\', '"', '0':
+			case 'n', 't', 'r', 'a', 'b', 'f', 'v', '\\', '"', '0', '#':
 				s.advance()
 			case 'x':
 				s.advance()

--- a/internal/token/token.go
+++ b/internal/token/token.go
@@ -25,6 +25,14 @@ const (
 	Int
 	Float
 	String
+	// A string with #{...} holes in it arrives as three kinds of piece:
+	// StringStart runs from the opening quote to the first `#{`, StringPart
+	// from a `}` to the next `#{`, and StringEnd from a `}` to the closing
+	// quote. The expression tokens between them are ordinary tokens, so the
+	// parser reads an interpolated string with the grammar it already has.
+	StringStart
+	StringPart
+	StringEnd
 	Bool
 	Nil
 
@@ -108,12 +116,15 @@ var names = [...]string{
 	Newline: "newline",
 	Comment: "comment",
 
-	Ident:  "identifier",
-	Int:    "integer",
-	Float:  "float",
-	String: "string",
-	Bool:   "boolean",
-	Nil:    "nil",
+	Ident:       "identifier",
+	Int:         "integer",
+	Float:       "float",
+	String:      "string",
+	StringStart: "string",
+	StringPart:  "string",
+	StringEnd:   "string",
+	Bool:        "boolean",
+	Nil:         "nil",
 
 	Assign:      "=",
 	AssignPlus:  "+=",

--- a/testdata/semantics/literals/string-interpolation.ari
+++ b/testdata/semantics/literals/string-interpolation.ari
@@ -1,0 +1,23 @@
+// Printing a message with a value in it used to be a chain of conversions,
+// because `+` does not coerce and println took one argument.
+let name = "Ada"
+let n = 3
+println("user #{name} has #{n} items")
+
+// A hole renders the way println renders it — String, not Inspect — so a
+// collection prints and a string in a hole does not come out quoted.
+println("#{1 + 2}")
+println("#{[1, 2]}")
+println("#{[:a => 1]}")
+println("#{name}")
+
+// Holes hold whole expressions, and a string inside one may interpolate too.
+println("call #{String.upper(name)}")
+println("nested #{ "inner #{n}" } done")
+
+// A `#` is only special before a `{`, and `\#` opts out.
+println("hash # alone")
+println("escaped \#{name}")
+
+// A raw string processes nothing, interpolation included.
+println(`raw #{name}`)

--- a/testdata/semantics/literals/string-interpolation.out
+++ b/testdata/semantics/literals/string-interpolation.out
@@ -1,0 +1,11 @@
+user Ada has 3 items
+3
+[1, 2]
+[:a => 1]
+Ada
+call ADA
+nested inner 3 done
+hash # alone
+escaped #{name}
+raw #{name}
+--- exit: 0

--- a/testdata/semantics/runtime/println-arity.ari
+++ b/testdata/semantics/runtime/println-arity.ari
@@ -1,1 +1,4 @@
+// This case pinned println's arity of one, which is no longer the rule: the
+// arguments are joined with a space. The name is kept so the change is visible
+// in this file's history rather than in a file that appeared from nowhere.
 println("a", "b")

--- a/testdata/semantics/runtime/println-arity.out
+++ b/testdata/semantics/runtime/println-arity.out
@@ -1,4 +1,2 @@
-println-arity.ari:1:1: error: println() expects 1 argument(s), got 2
-  println("a", "b")
-  ^^^^^^^^^^^^^^^^^
---- exit: 1
+a b
+--- exit: 0

--- a/testdata/semantics/runtime/println-variadic.ari
+++ b/testdata/semantics/runtime/println-variadic.ari
@@ -1,0 +1,11 @@
+// println and print take any number of arguments, joined with a space. The
+// arity of one was left alone during the rewrite because the "expects exactly
+// 1 argument" messages in the goldens were a cascade from something else — a
+// reason not to change it while chasing a different bug, not a reason to keep
+// it.
+println("count:", 3)
+println("a", "b", "c")
+println()
+print("x", "y")
+println()
+println("mixed", 1, 2.5, true, nil, [1, 2], :atom)

--- a/testdata/semantics/runtime/println-variadic.out
+++ b/testdata/semantics/runtime/println-variadic.out
@@ -1,0 +1,6 @@
+count: 3
+a b c
+
+x y
+mixed 1 2.5 true nil [1, 2] :atom
+--- exit: 0


### PR DESCRIPTION
Putting a value in a message was one of the clumsiest things in Aria, because three restrictions compounded: `+` does not coerce, `println` took exactly one argument, and there was no interpolation. Every mixed message was a chain of conversions.

## What changed

- **`"user #{name} has #{n} items"`.** A hole holds a whole expression, and the value renders the way `println` renders it — `String`, not `Inspect` — so `"#{[1, 2]}"` is `[1, 2]`. `#` is only special before a `{`, and `\#` opts out. A raw literal processes nothing, interpolation included.
- The scanner hands an interpolated literal over as pieces (`StringStart`, the hole's tokens, `StringPart`..., `StringEnd`) rather than one token the parser re-scans, so the expressions parse with the existing grammar and their spans point at where they are written. Aria has no other use for braces, so a `}` while an interpolation is open always closes it — nesting is a counter, and `"a #{ "b #{c}" } d"` falls out.
- It lands as `ast.Interpolation` rather than desugaring to `+` with `String(...)` calls. A desugaring would make `"#{[1, 2]}"` an error where `println` prints it, and naming `String` would let anything shadowing that name change every interpolated string in scope.
- **`println` and `print` take any number of arguments**, joined with a space.
- `literals/string-interpolation` and `runtime/println-variadic` added; `runtime/println-arity` re-recorded deliberately, keeping its name so the change shows in that file's history. `FuzzScan` and `FuzzParse` each run for 45s.

Closes #12