### PR TITLE
Check type annotations before the program runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ go test ./internal/parser/  -run=Fuzz -fuzz=FuzzParse -fuzztime=30s
 
 ## The characterization suite is the arbiter
 
-`testdata/semantics/` holds 179 `.ari` files, each with a `.out` golden recording exactly
+`testdata/semantics/` holds 184 `.ari` files, each with a `.out` golden recording exactly
 what the interpreter prints and what it exits with.
 
 **If a golden changes, you changed the language.** That is either the point of your change

--- a/README.md
+++ b/README.md
@@ -600,6 +600,17 @@ println(add(5, "two"))
 
 Aria is not a strong typed language, so type hinting is completely optional. Generally, it's a good idea to use it as a validation measure. Once you enforce a certain type, you'll be sure of how the function executes.
 
+A hint names one of `Nil`, `Bool`, `Int`, `Float`, `String`, `Atom`, `Array`, `Dictionary`, `Function`, `Module` or `Any`, and anything else is an error before the program runs — the same for `is` and `as`. `Any` accepts everything, which is how you say "anything" out loud rather than by leaving the hint off:
+
+```swift
+let identity = func (v: Any) -> Any
+  v
+end
+println(identity([1, 2]))
+```
+
+A default is checked against its own parameter's hint, so `func (n: Int = "oops")` is an error rather than a hint that lies to every caller who omits the argument.
+
 ### Default Parameters
 
 Function parameters can have default values, used when the parameters are omitted from function calls.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -171,6 +171,37 @@ The evaluator hoists to match, in `Interp.Run` and again for an imported file. H
 only one of the two would let a name resolve and then not be there at runtime — `eval`'s
 Identifier case, the one whose comment says the two passes cannot disagree.
 
+**Type annotations are checked here, not at runtime.** Aria has hints, and almost nothing
+used to look at them before the program ran.
+
+`is` was a string comparison against `Type().String()` with the right-hand side never
+resolved, so `5 is Banana` was a permanently-false test rather than a typo. The set of type
+names is fixed and known, so `is`, `as`, parameter hints and return hints are all checked
+against it.
+
+A parameter's default is checked against its own annotation. `checkParamType` ran only on
+arguments actually passed, so `func (n: Int = "oops")` bound the default unchecked and the
+hint was a lie for every caller that omitted the argument. A literal default is checked
+here; anything else is checked when it is evaluated.
+
+Module members are checked for the modules this pass can see — the standard library, whose
+members are known before the user's program is parsed, and anything declared in the same
+file. `resolver.moduleAccess` used to skip this on the grounds that matching members across
+files is the evaluator's job, which is true only for a module in an imported file. Moving
+"not found" from runtime to a diagnostic is the resolver's stated reason for existing, and
+a mistyped `Enum.sizze` is the same class of mistake as a mistyped variable.
+
+**`Any` is a name a hint may use.** Without it, the way to say "accepts anything" was to say
+nothing, so an unannotated parameter was ambiguous between that and "not yet annotated".
+`x is Any` is true, `x as Any` is `x`, and `: Any` accepts everything.
+
+**Nullable and union annotations are deliberately not here yet.** A parameter that
+legitimately takes `Int` or `nil` still cannot be annotated, which is why most of the
+standard library leaves its optional parameters bare. Both need real grammar in the
+annotation position — `Int?`, `Int | String` — and that is a type-syntax decision worth
+making once, alongside user-defined types, rather than improvised into a bug fix. `Any` is
+the honest way to say it in the meantime.
+
 **It also checks what only a tree walk can see.** Three mistakes are knowable before the
 program starts, and each was silent or late:
 
@@ -516,7 +547,7 @@ something the author of an Aria program can act on.
 
 ## The characterization suite
 
-`testdata/semantics/` holds 179 cases. Each `.ari` file has a `.out` golden recording
+`testdata/semantics/` holds 184 cases. Each `.ari` file has a `.out` golden recording
 exactly what the interpreter prints and what it exits with.
 
 ```bash

--- a/internal/interp/builtins.go
+++ b/internal/interp/builtins.go
@@ -597,6 +597,10 @@ func (i *Interp) wantString(name string, args []value.Value, span source.Span) s
 // a message rather than reporting, so both call sites can attach their own span.
 func Convert(v value.Value, to string) (value.Value, string) {
 	switch to {
+	case value.Any:
+		// Everything is already an Any.
+		return v, ""
+
 	case "String":
 		switch v := v.(type) {
 		case value.String:

--- a/internal/interp/callable.go
+++ b/internal/interp/callable.go
@@ -138,7 +138,12 @@ func (i *Interp) callFunction(fn *Function, args []value.Value, span source.Span
 			}
 			continue
 		}
-		scope.define(p.Name.Value, i.eval(p.Default, fn.Env))
+		// The default is checked against the annotation too. checkParamType ran
+		// only on arguments actually passed, so a default was bound unchecked
+		// and the hint was a lie for every caller that omitted the argument.
+		def := i.eval(p.Default, fn.Env)
+		i.checkParamType(p, def, i.curFile(), p.Default.Span())
+		scope.define(p.Name.Value, def)
 	}
 
 	if len(args) < required {
@@ -171,7 +176,8 @@ func (i *Interp) callFunction(fn *Function, args []value.Value, span source.Span
 		i.signal, i.retval = sigNone, nil
 	}
 
-	if decl.ReturnType != nil && result.Type().String() != decl.ReturnType.Value {
+	if decl.ReturnType != nil && decl.ReturnType.Value != value.Any &&
+		result.Type().String() != decl.ReturnType.Value {
 		i.failIn(callerFile, span, "%s declares it returns %s but returned %s",
 			fnName(decl), decl.ReturnType.Value, result.Type())
 	}
@@ -179,7 +185,7 @@ func (i *Interp) callFunction(fn *Function, args []value.Value, span source.Span
 }
 
 func (i *Interp) checkParamType(p *ast.FunctionParameter, arg value.Value, file *source.File, span source.Span) {
-	if p.Type == nil {
+	if p.Type == nil || p.Type.Value == value.Any {
 		return
 	}
 	if arg.Type().String() != p.Type.Value {

--- a/internal/interp/interp.go
+++ b/internal/interp/interp.go
@@ -288,6 +288,11 @@ func (i *Interp) eval(n ast.Node, e *env) value.Value {
 	case *ast.Pipe:
 		return i.evalPipe(n, e)
 	case *ast.Is:
+		// `Any` is a name a hint may use, and everything is one.
+		if n.Right.Value == value.Any {
+			i.eval(n.Left, e)
+			return value.True
+		}
 		return value.Of(i.eval(n.Left, e).Type().String() == n.Right.Value)
 	case *ast.As:
 		return i.convert(i.eval(n.Left, e), n.Right.Value, n.Span())

--- a/internal/interp/interp_test.go
+++ b/internal/interp/interp_test.go
@@ -1571,3 +1571,65 @@ println(squares)`); got != "[1, 4, 9, 16]\n" {
 		t.Errorf("got %q", got)
 	}
 }
+
+// Aria has type annotations and almost nothing used to look at them before the
+// program ran.
+func TestTypeAnnotationsAreChecked(t *testing.T) {
+	// `is` was a string comparison with the right side never resolved, so a
+	// typo was a permanently-false test.
+	fails(t, `println(5 is Banana)`, "'Banana' is not a type")
+	fails(t, `println(5 as Banana)`, "'Banana' is not a type")
+	fails(t, `let f = func (n: Banana) do n end`, "'Banana' is not a type")
+	fails(t, `let f = func () -> Fruit do 1 end`, "'Fruit' is not a type")
+
+	// A default was bound unchecked, so the hint was a lie for every caller
+	// that omitted the argument.
+	fails(t, `let f = func (n: Int = "oops") do n end`, "declared Int but defaults to String")
+
+	// A mistyped module member was a runtime error for something knowable
+	// before the program starts.
+	withStdlibFails(t, `println(Enum.sizze([1, 2]))`, "module 'Enum' has no member 'sizze'")
+	fails(t, `module M
+  let a = 1
+end
+println(M.nope)`, "module 'M' has no member 'nope'")
+
+	// A dictionary reached with a dot is not a module, and is not checked.
+	if got := output(t, `let cfg = [:a => 1]
+println(cfg.a)`); got != "1\n" {
+		t.Errorf("got %q", got)
+	}
+}
+
+// `Any` is a name a hint may use: without it, the way to say "accepts anything"
+// was to say nothing.
+func TestAnyAnnotation(t *testing.T) {
+	tests := []struct{ src, want string }{
+		{`let f = func (v: Any) -> Any do v end
+println(f([1, 2]))`, "[1, 2]"},
+		{`println(5 is Any)`, "true"},
+		{`println(nil is Any)`, "true"},
+		{`println(5 as Any)`, "5"},
+	}
+	for _, test := range tests {
+		if got := output(t, test.src); got != test.want+"\n" {
+			t.Errorf("%s: got %q, want %q", test.src, got, test.want)
+		}
+	}
+}
+
+// withStdlibFails requires src to fail with the standard library loaded.
+func withStdlibFails(t *testing.T, src, want string) {
+	t.Helper()
+	var out, errOut strings.Builder
+	_, err := interp.Eval("test.ari", src, interp.Options{
+		Out: &out, Err: &errOut, In: strings.NewReader(""),
+	})
+	if err == nil {
+		t.Errorf("%q: expected a failure mentioning %q, but it succeeded", src, want)
+		return
+	}
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("%q: failure did not mention %q:\n%v", src, want, err)
+	}
+}

--- a/internal/interp/run.go
+++ b/internal/interp/run.go
@@ -58,9 +58,7 @@ func Run(file *source.File, opts Options) bool {
 	}
 
 	r := resolver.New(file, bag)
-	for _, name := range stdlib.Names() {
-		r.PredeclareModule(name)
-	}
+	i.predeclareModules(r)
 	for name := range i.globals.vars {
 		r.Predeclare(name)
 	}
@@ -81,6 +79,23 @@ func Run(file *source.File, opts Options) bool {
 		return false
 	}
 	return true
+}
+
+// predeclareModules tells a resolver about every module that exists, with the
+// members each one declares, so an access to a missing member is a diagnostic
+// rather than a runtime error. The standard library is already evaluated by the
+// time this runs, so its members are real values rather than a guess.
+func (i *Interp) predeclareModules(r *resolver.Resolver) {
+	for _, name := range stdlib.Names() {
+		if m, ok := i.modules[name]; ok {
+			r.PredeclareModule(name, m.Names()...)
+			continue
+		}
+		r.PredeclareModule(name)
+	}
+	for name, m := range i.modules {
+		r.PredeclareModule(name, m.Names()...)
+	}
 }
 
 // loadStdlib parses, resolves and evaluates the embedded library.
@@ -157,9 +172,7 @@ func Eval(name, src string, opts Options) (value.Value, error) {
 	}
 
 	r := resolver.New(file, bag)
-	for _, n := range stdlib.Names() {
-		r.PredeclareModule(n)
-	}
+	i.predeclareModules(r)
 	for n := range i.globals.vars {
 		r.Predeclare(n)
 	}
@@ -235,19 +248,15 @@ func (s *Session) Eval(src string) (value.Value, error) {
 	}
 
 	r := resolver.New(file, bag)
-	for _, name := range stdlib.Names() {
-		r.PredeclareModule(name)
-	}
 	for name := range s.interp.globals.vars {
 		r.Predeclare(name)
 	}
 	for name := range s.declared {
 		r.Predeclare(name)
 	}
-	// A module declared on an earlier line is still declared.
-	for name := range s.interp.modules {
-		r.PredeclareModule(name)
-	}
+	// A module declared on an earlier line is still declared, and its members
+	// are known, so an access to one is checked like any other.
+	s.interp.predeclareModules(r)
 
 	info := r.Resolve(prog)
 	if bag.HasErrors() {

--- a/internal/resolver/corpus_test.go
+++ b/internal/resolver/corpus_test.go
@@ -108,6 +108,12 @@ var expectedResolveErrors = map[string]string{
 	"hoisting-not-for-values.ari":    "reads a non-function `let` before it is declared",
 	"hoisting-limits.ari":            "calls a later function from inside a function body",
 	"break-too-many-levels.ari":      "breaks out of more loops than it is inside",
+	"missing-member.ari":             "reads a module member that does not exist",
+	"non-let-member.ari":             "puts something other than a let in a module body",
+	"is-unknown-type.ari":            "tests against a name that is not a type",
+	"as-unknown-type.ari":            "converts to a name that is not a type",
+	"unknown-parameter-type.ari":     "annotates with names that are not types",
+	"default-type-violation.ari":     "gives a parameter a default its annotation forbids",
 }
 
 // Three cases that USED to fail now resolve cleanly, which is the point:

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -20,9 +20,12 @@
 package resolver
 
 import (
+	"strings"
+
 	"github.com/fadion/aria/internal/ast"
 	"github.com/fadion/aria/internal/diag"
 	"github.com/fadion/aria/internal/source"
+	"github.com/fadion/aria/internal/value"
 )
 
 // Builtins are the runtime functions available without declaration.
@@ -165,6 +168,11 @@ type Resolver struct {
 	// redeclaration.
 	hoisted map[*Binding]bool
 
+	// moduleMembers maps a module's binding to the names it declares, for the
+	// modules this pass can see: the standard library and anything declared in
+	// this file.
+	moduleMembers map[*Binding][]string
+
 	// loops and funcs count the enclosing loop and function bodies, so that
 	// break, continue and return can be checked where they mean something. A
 	// function body resets loops: a `break` inside a function nested in a loop
@@ -183,8 +191,9 @@ func New(file *source.File, diags *diag.Bag) *Resolver {
 			decls: map[*ast.Identifier]*Binding{},
 			sizes: map[ast.Node]int{},
 		},
-		modules: map[string]bool{},
-		hoisted: map[*Binding]bool{},
+		modules:       map[string]bool{},
+		hoisted:       map[*Binding]bool{},
+		moduleMembers: map[*Binding][]string{},
 	}
 	r.current = newScope(nil)
 	for _, name := range Builtins {
@@ -204,9 +213,12 @@ func (r *Resolver) Predeclare(name string) { r.predeclare(name, KindLet) }
 // entry in the module set. It used to be only the latter, which is why
 // resolveName had to let bare module names through unresolved and `let E = Enum`
 // then failed in the evaluator with "'Enum' is not defined".
-func (r *Resolver) PredeclareModule(name string) {
+func (r *Resolver) PredeclareModule(name string, members ...string) {
 	r.modules[name] = true
 	r.predeclare(name, KindLet)
+	if len(members) > 0 {
+		r.moduleMembers[r.current.names[name]] = members
+	}
 }
 
 func (r *Resolver) predeclare(name string, kind Kind) {
@@ -240,7 +252,28 @@ func (r *Resolver) collectModules(nodes []ast.Node) {
 			// reports the redeclaration, with the module's own message.
 			if n.Name != nil && !r.modules[n.Name.Value] {
 				r.modules[n.Name.Value] = true
-				r.declare(n.Name, KindLet, false)
+				b := r.declare(n.Name, KindLet, false)
+				// The members are right here, so an access can be checked
+				// against them rather than left to the evaluator.
+				if b != nil && n.Body != nil {
+					members, wellFormed := []string{}, true
+					for _, c := range n.Body.Nodes {
+						let, isLet := c.(*ast.Let)
+						if !isLet {
+							wellFormed = false
+							continue
+						}
+						if let.Name != nil {
+							members = append(members, let.Name.Value)
+						}
+					}
+					// A malformed body is reported on its own; checking members
+					// against it too would pile a second message onto one
+					// mistake.
+					if wellFormed {
+						r.moduleMembers[b] = members
+					}
+				}
 			}
 		case *ast.Import:
 			r.hasImport = true
@@ -402,10 +435,13 @@ func (r *Resolver) node(n ast.Node) {
 		r.pipeTarget(n.Right)
 
 	case *ast.Is:
-		// Only the left side is a value; the right is a type name.
+		// Only the left side is a value; the right names a type, which is a
+		// fixed set this pass can check.
 		r.node(n.Left)
+		r.typeName(n.Right)
 	case *ast.As:
 		r.node(n.Left)
+		r.typeName(n.Right)
 
 	case *ast.ExpressionList:
 		for _, c := range n.Elements {
@@ -471,6 +507,7 @@ func (r *Resolver) node(n ast.Node) {
 		// to know anything about modules — and `cfg.db.host`, `f().a` and
 		// `a[0].k` resolve for the same reason.
 		r.node(n.Left)
+		r.moduleMember(n)
 
 	// A control keyword outside the construct it controls is knowable here,
 	// and silent otherwise: Interp.Run stops its node loop on any signal, so a
@@ -656,10 +693,25 @@ func (r *Resolver) function(n *ast.Function) {
 	// Default values are evaluated in the ENCLOSING scope, so resolve them
 	// before opening the function's own.
 	for _, p := range n.Parameters {
-		if p != nil && p.Default != nil {
-			r.node(p.Default)
+		if p == nil {
+			continue
+		}
+		r.typeName(p.Type)
+		if p.Default == nil {
+			continue
+		}
+		r.node(p.Default)
+		// checkParamType runs only on arguments actually passed, so a default
+		// was bound unchecked and the annotation was a lie for every caller
+		// that omitted it. A literal default is knowable here.
+		if p.Type != nil && p.Type.Value != value.Any {
+			if got := literalType(p.Default); got != "" && got != p.Type.Value {
+				r.diags.Errorf(p.Default.Span(), "parameter '%s' is declared %s but defaults to %s",
+					p.Name.Value, p.Type.Value, got)
+			}
 		}
 	}
+	r.typeName(n.ReturnType)
 
 	r.push()
 	for _, p := range n.Parameters {
@@ -695,10 +747,17 @@ func (r *Resolver) module(n *ast.Module) {
 
 	r.push()
 
-	// First pass: declare every member.
+	// First pass: declare every member. A module body accepts only `let`, which
+	// the evaluator reported at runtime for a mistake plainly visible here.
 	for _, c := range n.Body.Nodes {
-		if let, ok := c.(*ast.Let); ok && let.Name != nil {
-			r.declare(let.Name, KindLet, false)
+		if let, ok := c.(*ast.Let); ok {
+			if let.Name != nil {
+				r.declare(let.Name, KindLet, false)
+			}
+			continue
+		}
+		if _, bad := c.(*ast.Bad); !bad && c != nil {
+			r.diags.Errorf(c.Span(), "a module body accepts only 'let' declarations")
 		}
 	}
 
@@ -712,4 +771,74 @@ func (r *Resolver) module(n *ast.Module) {
 	}
 
 	r.pop(n)
+}
+
+// typeName checks that id names a type an annotation may use.
+//
+// `is` was a string comparison against Type().String() and the resolver skipped
+// the right-hand side entirely, so `5 is Banana` was a permanently-false test
+// rather than a typo. The set is fixed and known here.
+func (r *Resolver) typeName(id *ast.Identifier) {
+	if id == nil || value.IsTypeName(id.Value) {
+		return
+	}
+	// One diagnostic rather than an error and a note: a note with the same span
+	// would draw the same line and caret underneath itself.
+	r.diags.Errorf(id.Span(), "'%s' is not a type: expected one of %s",
+		id.Value, strings.Join(value.TypeNames(), ", "))
+}
+
+// moduleMember checks an access against a module whose members are known.
+//
+// resolver.moduleAccess used to skip this on the grounds that matching members
+// across files is the evaluator's job. True for a module declared in an imported
+// file, which this pass never sees — but not for the standard library, whose
+// members are known before the user's program is parsed, and not for a module
+// declared in the same file. Moving "not found" from runtime to a diagnostic is
+// the resolver's stated reason for existing.
+func (r *Resolver) moduleMember(n *ast.Access) {
+	id, ok := n.Left.(*ast.Identifier)
+	if !ok || n.Name == nil {
+		return
+	}
+	ref, found := r.info.refs[id]
+	if !found {
+		return // undefined, or hidden behind an import; already handled
+	}
+	members, known := r.moduleMembers[ref.Binding]
+	if !known {
+		return // not a module, or one whose members this pass cannot see
+	}
+	for _, m := range members {
+		if m == n.Name.Value {
+			return
+		}
+	}
+	r.diags.Errorf(n.Name.Span(), "module '%s' has no member '%s'", id.Value, n.Name.Value)
+}
+
+// literalType is the type name of a node whose type is knowable without running
+// it, or "" for anything else.
+func literalType(n ast.Node) string {
+	switch n.(type) {
+	case *ast.Integer:
+		return "Int"
+	case *ast.Float:
+		return "Float"
+	case *ast.String, *ast.Interpolation:
+		return "String"
+	case *ast.Atom:
+		return "Atom"
+	case *ast.Boolean:
+		return "Bool"
+	case *ast.Nil:
+		return "Nil"
+	case *ast.Array:
+		return "Array"
+	case *ast.Dictionary:
+		return "Dictionary"
+	case *ast.Function:
+		return "Function"
+	}
+	return ""
 }

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -67,6 +67,33 @@ func (t Type) String() string {
 	return "Nil"
 }
 
+// Any is the annotation for "any type". It is not a Type — no value has it —
+// but it is a name a hint may use, so that an unannotated parameter means "not
+// yet annotated" and `: Any` means "anything, deliberately".
+const Any = "Any"
+
+// TypeNames are the names a type annotation, `is` or `as` may use.
+func TypeNames() []string {
+	names := make([]string, 0, int(TModule)+2)
+	for t := TNil; t <= TModule; t++ {
+		names = append(names, t.String())
+	}
+	return append(names, Any)
+}
+
+// IsTypeName reports whether s names a type an annotation may use.
+func IsTypeName(s string) bool {
+	if s == Any {
+		return true
+	}
+	for t := TNil; t <= TModule; t++ {
+		if t.String() == s {
+			return true
+		}
+	}
+	return false
+}
+
 // A Value is any Aria runtime value.
 type Value interface {
 	Type() Type

--- a/testdata/semantics/errors/unknown-parameter-type.ari
+++ b/testdata/semantics/errors/unknown-parameter-type.ari
@@ -1,0 +1,3 @@
+// A parameter or return hint naming something that is not a type was accepted
+// and then compared against, so it could never match.
+let f = func (n: Banana) -> Fruit do n end

--- a/testdata/semantics/errors/unknown-parameter-type.out
+++ b/testdata/semantics/errors/unknown-parameter-type.out
@@ -1,0 +1,7 @@
+unknown-parameter-type.ari:3:18: error: 'Banana' is not a type: expected one of Nil, Bool, Int, Float, String, Atom, Array, Dictionary, Function, Module, Any
+  let f = func (n: Banana) -> Fruit do n end
+                   ^^^^^^
+unknown-parameter-type.ari:3:29: error: 'Fruit' is not a type: expected one of Nil, Bool, Int, Float, String, Atom, Array, Dictionary, Function, Module, Any
+  let f = func (n: Banana) -> Fruit do n end
+                              ^^^^^
+--- exit: 1

--- a/testdata/semantics/functions/any-annotation.ari
+++ b/testdata/semantics/functions/any-annotation.ari
@@ -1,0 +1,16 @@
+// `Any` is a name a hint may use. Without it, the way to say "accepts anything"
+// was to say nothing, so an unannotated parameter was ambiguous between that and
+// "not yet annotated".
+let f = func (v: Any) -> Any do v end
+println(f(1))
+println(f("x"))
+println(f([1, 2]))
+println(5 is Any)
+println("x" is Any)
+println(nil is Any)
+println(5 as Any)
+
+// A default still has to match a real annotation.
+let g = func (n: Int = 3) -> Int do n * 2 end
+println(g())
+println(g(5))

--- a/testdata/semantics/functions/any-annotation.out
+++ b/testdata/semantics/functions/any-annotation.out
@@ -1,0 +1,10 @@
+1
+x
+[1, 2]
+true
+true
+true
+5
+6
+10
+--- exit: 0

--- a/testdata/semantics/functions/default-type-violation.ari
+++ b/testdata/semantics/functions/default-type-violation.ari
@@ -1,0 +1,4 @@
+// checkParamType ran only on arguments actually passed, so a default was bound
+// unchecked and the annotation was a lie for every caller that omitted it.
+let f = func (n: Int = "oops") do n end
+println(f())

--- a/testdata/semantics/functions/default-type-violation.out
+++ b/testdata/semantics/functions/default-type-violation.out
@@ -1,0 +1,4 @@
+default-type-violation.ari:3:24: error: parameter 'n' is declared Int but defaults to String
+  let f = func (n: Int = "oops") do n end
+                         ^^^^^^
+--- exit: 1

--- a/testdata/semantics/operators/as-unknown-type.ari
+++ b/testdata/semantics/operators/as-unknown-type.ari
@@ -1,0 +1,2 @@
+// `as` reported "unknown type" at runtime for the same knowable mistake.
+println(5 as Banana)

--- a/testdata/semantics/operators/as-unknown-type.out
+++ b/testdata/semantics/operators/as-unknown-type.out
@@ -1,0 +1,4 @@
+as-unknown-type.ari:2:14: error: 'Banana' is not a type: expected one of Nil, Bool, Int, Float, String, Atom, Array, Dictionary, Function, Module, Any
+  println(5 as Banana)
+               ^^^^^^
+--- exit: 1

--- a/testdata/semantics/operators/is-unknown-type.ari
+++ b/testdata/semantics/operators/is-unknown-type.ari
@@ -1,0 +1,5 @@
+// `is` was a string comparison against Type().String(), and the resolver skipped
+// the right-hand side entirely, so a typo became a permanently-false test rather
+// than a mistake. The set of type names is fixed and known before the program
+// runs.
+println(5 is Banana)

--- a/testdata/semantics/operators/is-unknown-type.out
+++ b/testdata/semantics/operators/is-unknown-type.out
@@ -1,0 +1,4 @@
+is-unknown-type.ari:5:14: error: 'Banana' is not a type: expected one of Nil, Bool, Int, Float, String, Atom, Array, Dictionary, Function, Module, Any
+  println(5 is Banana)
+               ^^^^^^
+--- exit: 1


### PR DESCRIPTION
Aria has type annotations and almost nothing looked at them before the program ran. Three holes, all the same class of mistake the resolver exists to catch.

## What changed

- **`is` and `as` against a name that is not a type are resolver errors.** `is` was a string comparison against `Type().String()` with the right side never resolved, so `5 is Banana` was a permanently-false test rather than a typo. Parameter and return hints are checked the same way.
- **A parameter's default is checked against its own annotation.** `checkParamType` ran only on arguments actually passed, so `func (n: Int = "oops")` bound the default unchecked and the hint lied to every caller that omitted the argument. Literal defaults at resolve time, anything else when evaluated.
- **Module members are checked** for the modules the resolver can see — the standard library, whose members are known before the user's program is parsed, and anything declared in the same file. A mistyped `Enum.sizze` is the same class of mistake as a mistyped variable.
- That also moves "a module body accepts only `let` declarations" to the resolver. A malformed body has its members left unrecorded, so the missing member isn't reported on top of it.

## The two decisions

- **`Any` is a name a hint may use.** Without it, the way to say "accepts anything" was to say nothing, so an unannotated parameter was ambiguous between that and "not yet annotated".
- **Nullable and union annotations are deliberately not here.** Both need real grammar in the annotation position — `Int?`, `Int | String` — and that is a type-syntax decision worth making once alongside user-defined types rather than improvised into a bug fix. Recorded in `docs/architecture.md`.

Five cases added, plus Go tests. `modules/missing-member` and `modules/non-let-member` turn out byte-identical — the resolver's message and span already matched what the evaluator produced — so no existing golden changed.

Closes #17