### PR TITLE
Nil-coalescing ??, safe navigation ?., and do...end as an expression

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ go test ./internal/parser/  -run=Fuzz -fuzz=FuzzParse -fuzztime=30s
 
 ## The characterization suite is the arbiter
 
-`testdata/semantics/` holds 184 `.ari` files, each with a `.out` golden recording exactly
+`testdata/semantics/` holds 187 `.ari` files, each with a `.out` golden recording exactly
 what the interpreter prints and what it exits with.
 
 **If a golden changes, you changed the language.** That is either the point of your change

--- a/README.md
+++ b/README.md
@@ -466,6 +466,7 @@ By order of precedence, loosest first:
 
 ```
 ||                    OR
+??                    nil-coalescing
 &&                    AND
 == != < <= > >=       equality and comparison
 |                     bitwise OR
@@ -477,6 +478,23 @@ By order of precedence, loosest first:
 * / %                 multiplication, division, modulo
 **                    power (right associative)
 ! ~ -                 prefix NOT, bitwise NOT, negation
+```
+
+`??` yields its left side unless it is `nil`, and short-circuits. It tests for `nil` and not for truthiness, which is the whole point of having it alongside `||`:
+
+```swift
+let config = [:retries => 0]
+println(config["port"] ?? 8080) // 8080
+println(config[:retries] ?? 3)  // 0, because 0 is not nil
+println(0 || 5)                 // true, which is why || can't do this job
+```
+
+A dot can be written `?.`, which yields `nil` as soon as a link is `nil` rather than failing on the next access:
+
+```swift
+let cfg = [:db => [:host => "localhost"]]
+println(cfg?.db?.host)
+println(cfg?.missing?.host ?? "none")
 ```
 
 Two of these are worth a second look, because they read the other way round in some
@@ -793,6 +811,19 @@ let add = func x, factor
   x + factor(x)
 end
 add(5, (x) -> x * 2)
+```
+
+## Blocks
+
+`do ... end` is an expression. It yields its last value and has a scope of its own, which is how you give a name to something built in a few steps without leaking the steps:
+
+```swift
+let area = do
+  let width = 6
+  let height = 7
+  width * height
+end
+println(area) // 42
 ```
 
 ## Conditionals

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -92,19 +92,20 @@ One table, in `internal/parser/precedence.go`, loosest to tightest:
 | 3 | `->` | right |
 | 4 | `? :` | right |
 | 5 | `\|\|` | left |
-| 6 | `&&` | left |
-| 7 | `==` `!=` `<` `<=` `>` `>=` | left |
-| 8 | `\|` | left |
-| 9 | `^` | left |
-| 10 | `&` | left |
-| 11 | `..` | left |
-| 12 | `<<` `>>` | left |
-| 13 | `+` `-` | left |
-| 14 | `*` `/` `%` | left |
-| 15 | `**` | **right** |
-| 16 | prefix `!` `~` `-` | — |
-| 17 | `(` call, `[` index, `.` access | left |
-| 18 | `is` `as` | left |
+| 6 | `??` | left |
+| 7 | `&&` | left |
+| 8 | `==` `!=` `<` `<=` `>` `>=` | left |
+| 9 | `\|` | left |
+| 10 | `^` | left |
+| 11 | `&` | left |
+| 12 | `..` | left |
+| 13 | `<<` `>>` | left |
+| 14 | `+` `-` | left |
+| 15 | `*` `/` `%` | left |
+| 16 | `**` | **right** |
+| 17 | prefix `!` `~` `-` | — |
+| 18 | `(` call, `[` index, `.` and `?.` access | left |
+| 19 | `is` `as` | left |
 
 Three of these are worth explaining, because each was wrong before and each is easy to
 get wrong again.
@@ -113,7 +114,7 @@ get wrong again.
 grouped as `false && (false || true)` and evaluated to `false` where every other language
 gives `true`. A silent wrong answer with no error attached.
 
-**Bitwise binds tighter than comparison** (levels 7–10). This is Python's ordering and the
+**Bitwise binds tighter than comparison** (levels 8–11). This is Python's ordering and the
 inverse of C's, and it is easy to write down backwards. `6 & 3 == 3` groups as
 `(6 & 3) == 3`. Under C's ordering it groups as `6 & (3 == 3)`, which in Aria is a type
 error rather than a subtle bug — but a type error on valid-looking code is still bad.
@@ -467,6 +468,30 @@ spends a section on. A count needs no new token, where a label would; it reads p
 two, but two is the case that comes up. The resolver counts the loops a `break` is inside,
 so `break 3` inside two is a diagnostic rather than an unwind out of the enclosing function.
 
+## Nil is threaded, not tested for truth
+
+Reading a missing array index or dictionary key yields `nil` rather than failing, so
+threading nil is an ordinary thing to be doing in Aria — and there was nothing to do it
+with. `||` cannot substitute because it coerces: `0 || 5` is `true`, not `0`.
+
+`a ?? b` yields `a` unless it is `nil`, and short-circuits, so the default is not evaluated
+when the left side is there. It tests for `nil` specifically rather than for truthiness,
+which is the whole point of having it alongside `||`.
+
+`a?.b` yields `nil` as soon as a link is `nil`, and answers `nil` for a missing key too —
+subscripting already answers `nil` for the same read, and `?.` is how a caller says it
+expects one.
+
+The scanner absorbs a trailing `?` into a name, since `empty?` is one token — but not when
+a dot follows, or `cfg?.db` would read as a name called `cfg?`. That makes `empty?.x`
+unwritable as a member access on the result of `empty?`; parenthesise it. That is the side
+of the ambiguity worth losing, since the other side is every safe navigation there is.
+
+**`do ... end` is an expression** with its own scope, yielding its last value. Everything in
+Aria is expression-valued except a block, which was the one place the claim was not true.
+`ast.Block` and `evalBlock` already did exactly this; it needed a prefix parse and nothing
+else.
+
 ## Ranges and slicing
 
 `..` builds an array. It is a value like any other, so `Array(1..5)`, `Enum.map(1..5, f)`
@@ -547,7 +572,7 @@ something the author of an Aria program can act on.
 
 ## The characterization suite
 
-`testdata/semantics/` holds 184 cases. Each `.ari` file has a `.out` golden recording
+`testdata/semantics/` holds 187 cases. Each `.ari` file has a `.out` golden recording
 exactly what the interpreter prints and what it exits with.
 
 ```bash

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -539,9 +539,19 @@ type Access struct {
 	Base
 	Left Node
 	Name *Identifier
+	// Safe is `?.`, which yields nil as soon as a link is nil instead of
+	// failing. Reading a missing key already yields nil, so threading nil
+	// through a chain is an ordinary thing to be doing in Aria.
+	Safe bool
 }
 
-func (n *Access) Inspect() string { return n.Left.Inspect() + "." + n.Name.Inspect() }
+func (n *Access) Inspect() string {
+	dot := "."
+	if n.Safe {
+		dot = "?."
+	}
+	return n.Left.Inspect() + dot + n.Name.Inspect()
+}
 
 // Import splices another source file into this scope.
 type Import struct {

--- a/internal/interp/callable.go
+++ b/internal/interp/callable.go
@@ -253,6 +253,12 @@ func (i *Interp) evalModule(n *ast.Module, e *env) {
 func (i *Interp) evalAccess(n *ast.Access, e *env) value.Value {
 	left := i.eval(n.Left, e)
 
+	// `?.` stops at the first nil link rather than failing, which is what makes
+	// a chain of them worth writing.
+	if n.Safe && left == value.NilValue {
+		return value.NilValue
+	}
+
 	switch v := left.(type) {
 	case *Module:
 		member, found := v.Member(n.Name.Value)
@@ -266,6 +272,11 @@ func (i *Interp) evalAccess(n *ast.Access, e *env) value.Value {
 		// text, so `config.host` finds :host and "host" alike.
 		if member, found := v.Get(value.String(n.Name.Value)); found {
 			return member
+		}
+		if n.Safe {
+			// A missing key is a nil link, and `?.` is how a caller says it
+			// expects one. Subscripting already answers nil for the same read.
+			return value.NilValue
 		}
 		i.fail(n.Name.Span(), "no key '%s' in the dictionary", n.Name.Value)
 	}

--- a/internal/interp/interp.go
+++ b/internal/interp/interp.go
@@ -1080,6 +1080,14 @@ func (i *Interp) evalInfix(n *ast.Infix, e *env) value.Value {
 			return value.True
 		}
 		return value.Of(value.Truthy(i.eval(n.Right, e)))
+	case "??":
+		// nil, not falsy: that is the whole point of having it alongside `||`,
+		// which coerces, so `0 || 5` is true rather than 0. Short-circuits, so
+		// the default is not evaluated when the left side is there.
+		if left := i.eval(n.Left, e); left != value.NilValue {
+			return left
+		}
+		return i.eval(n.Right, e)
 	}
 
 	return i.applyInfix(n.Operator, i.eval(n.Left, e), i.eval(n.Right, e), n.Span())

--- a/internal/interp/interp_test.go
+++ b/internal/interp/interp_test.go
@@ -1633,3 +1633,95 @@ func withStdlibFails(t *testing.T, src, want string) {
 		t.Errorf("%q: failure did not mention %q:\n%v", src, want, err)
 	}
 }
+
+// `??` tests for nil, not for truthiness — that is the whole point of having it
+// alongside `||`, which coerces, so `0 || 5` is true rather than 0.
+func TestNilCoalescing(t *testing.T) {
+	tests := []struct{ src, want string }{
+		{`println([:a => 1]["b"] ?? 8080)`, "8080"},
+		{`println([:a => 1][:a] ?? 8080)`, "1"},
+		{`println(0 ?? 5)`, "0"},
+		{`println(0 || 5)`, "true"},
+		{`println("" ?? "fallback")`, ""},
+		{`println(false ?? true)`, "false"},
+		{`println(nil ?? "fallback")`, "fallback"},
+		// Binds tighter than || and looser than &&.
+		{`println(nil ?? false || true)`, "true"},
+	}
+	for _, test := range tests {
+		if got := output(t, test.src); got != test.want+"\n" {
+			t.Errorf("%s: got %q, want %q", test.src, got, test.want)
+		}
+	}
+
+	// It short-circuits: the default is not evaluated when the left side is
+	// there.
+	if got := output(t, `var runs = 0
+let fallback = func () do
+  runs += 1
+  "computed"
+end
+println("present" ?? fallback())
+println(runs)`); got != "present\n0\n" {
+		t.Errorf("got %q", got)
+	}
+}
+
+// `?.` yields nil as soon as a link is nil, instead of failing on the next
+// access.
+func TestSafeNavigation(t *testing.T) {
+	tests := []struct{ src, want string }{
+		{`let cfg = [:db => [:host => "x"]]
+println(cfg?.db?.host)`, "x"},
+		{`let cfg = [:db => [:host => "x"]]
+println(cfg?.missing?.host)`, "nil"},
+		{`let cfg = [:db => [:host => "x"]]
+println(cfg?.db?.missing)`, "nil"},
+		{`let cfg = [:db => 1]
+println(cfg?.missing ?? "default")`, "default"},
+	}
+	for _, test := range tests {
+		if got := output(t, test.src); got != test.want+"\n" {
+			t.Errorf("%s: got %q, want %q", test.src, got, test.want)
+		}
+	}
+
+	// A trailing `?` still belongs to a name when no dot follows.
+	if got := withStdlib(t, `println(Enum.empty?([]))`); got != "true" {
+		t.Errorf("got %q", got)
+	}
+
+	// A plain dot still fails on a missing key, which is what `?.` opts out of.
+	fails(t, `let cfg = [:a => 1]
+println(cfg.missing)`, "no key 'missing'")
+}
+
+// `do ... end` is an expression with its own scope: the one place Aria's
+// everything-is-an-expression claim was not true.
+func TestBlockExpression(t *testing.T) {
+	if got := output(t, `let x = do
+  let a = 21
+  a * 2
+end
+println(x)`); got != "42\n" {
+		t.Errorf("got %q", got)
+	}
+
+	// Its own scope: what it declares does not outlive it.
+	fails(t, `let x = do
+  let inner = 1
+  inner
+end
+println(inner)`, "'inner' is not defined")
+
+	// And it shadows rather than reassigns.
+	if got := output(t, `let outer = "kept"
+let y = do
+  let outer = "shadowed"
+  outer
+end
+println(y)
+println(outer)`); got != "shadowed\nkept\n" {
+		t.Errorf("got %q", got)
+	}
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -338,6 +338,8 @@ func (p *Parser) parsePrefix() ast.Node {
 		return p.parseWhile(false)
 	case token.Until:
 		return p.parseWhile(true)
+	case token.Do:
+		return p.parseBlockExpression()
 	case token.For:
 		return p.parseFor()
 	case token.Module:
@@ -366,7 +368,9 @@ func (p *Parser) parseInfix(left ast.Node) ast.Node {
 	case token.LBracket:
 		return p.parseSubscript(left)
 	case token.Dot:
-		return p.parseAccess(left)
+		return p.parseAccess(left, false)
+	case token.SafeDot:
+		return p.parseAccess(left, true)
 	case token.Pipe:
 		return p.parsePipe(left)
 	case token.Arrow:
@@ -890,7 +894,7 @@ func (p *Parser) parseSubscript(left ast.Node) ast.Node {
 // identifier, which is what stopped `.` from chaining; the old parser also
 // called TokenLexeme on it without checking for nil, which is the crash a
 // fuzzer found in under a second.
-func (p *Parser) parseAccess(left ast.Node) ast.Node {
+func (p *Parser) parseAccess(left ast.Node, safe bool) ast.Node {
 	if !p.expectPeek(token.Ident) {
 		return &ast.Bad{Base: ast.Base{Sp: span(left.Span(), p.tok.Span)}, Text: "."}
 	}
@@ -899,6 +903,7 @@ func (p *Parser) parseAccess(left ast.Node) ast.Node {
 		Base: ast.Base{Sp: span(left.Span(), p.tok.Span)},
 		Left: left,
 		Name: &ast.Identifier{Base: ast.Base{Sp: p.tok.Span}, Value: p.text(p.tok)},
+		Safe: safe,
 	}
 }
 
@@ -1092,6 +1097,23 @@ func markDiscarded(nodes []ast.Node) {
 			loop.Discard = i < len(nodes)-1
 		}
 	}
+}
+
+// parseBlockExpression reads `do ... end` in expression position.
+//
+// Everything in Aria is expression-valued except a block, which is the one place
+// the claim was not true. ast.Block and evalBlock already do exactly this; it
+// needed a prefix parse and nothing else.
+func (p *Parser) parseBlockExpression() ast.Node {
+	start := p.tok.Span
+	p.advance()
+
+	block := p.parseBlock(token.End)
+	if !p.at(token.End) {
+		return p.bad(span(start, p.tok.Span), "missing 'end' to close 'do'")
+	}
+	block.Sp = span(start, p.tok.Span)
+	return block
 }
 
 // parseBreak reads `break` or `break N`, where N is how many enclosing loops to

--- a/internal/parser/precedence.go
+++ b/internal/parser/precedence.go
@@ -22,6 +22,7 @@ const (
 	precArrow  // ->
 	precTernary
 	precOr         // ||
+	precCoalesce   // ??
 	precAnd        // &&
 	precComparison // == != < <= > >=
 	precBitOr      // |
@@ -53,8 +54,9 @@ var leftBindingPower = [...]int{
 	token.Arrow:    precArrow,
 	token.Question: precTernary,
 
-	token.Or:  precOr,
-	token.And: precAnd,
+	token.Or:       precOr,
+	token.Coalesce: precCoalesce,
+	token.And:      precAnd,
 
 	token.BitOr:  precBitOr,
 	token.BitXor: precBitXor,
@@ -84,6 +86,7 @@ var leftBindingPower = [...]int{
 	token.LParen:   precCall,
 	token.LBracket: precCall,
 	token.Dot:      precCall,
+	token.SafeDot:  precCall,
 
 	token.Is: precTypeOp,
 	token.As: precTypeOp,
@@ -106,7 +109,7 @@ func rightBindingPower(kind token.Kind) int {
 	case token.Power:
 		// Right-associative: 2 ** 3 ** 2 is 2 ** (3 ** 2).
 		return precPower - 1
-	case token.Or, token.And:
+	case token.Or, token.And, token.Coalesce:
 		// Left-associative, so a && b && c is (a && b) && c.
 		return lbp(kind)
 	}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -247,6 +247,14 @@ func (s *Scanner) scanOperator(start source.Pos) (token.Token, bool) {
 	case '~':
 		return s.token(token.BitNot, start), true
 	case '?':
+		switch s.ch {
+		case '?':
+			s.advance()
+			return s.token(token.Coalesce, start), true
+		case '.':
+			s.advance()
+			return s.token(token.SafeDot, start), true
+		}
 		return s.token(token.Question, start), true
 	case ',':
 		return s.token(token.Comma, start), true
@@ -310,7 +318,13 @@ func (s *Scanner) scanIdent(start source.Pos) token.Token {
 	}
 	// A trailing ? or ! belongs to the name, but only one and only at the end,
 	// so `a?b` is still one identifier while `a ? b : c` stays a ternary.
-	if s.ch == '?' || s.ch == '!' {
+	//
+	// `?.` is the exception: a `?` followed by a dot is safe navigation, not the
+	// end of a name, so `cfg?.db` reads as cfg and `?.db` rather than as a name
+	// called `cfg?`. That makes `empty?.x` unwritable as a member access on the
+	// result of `empty?` — parenthesise it — which is the side of the ambiguity
+	// worth losing, since the other side is every safe navigation there is.
+	if (s.ch == '?' && s.peek() != '.') || s.ch == '!' {
 		s.advance()
 	}
 

--- a/internal/token/token.go
+++ b/internal/token/token.go
@@ -69,6 +69,8 @@ const (
 	Arrow       // ->
 	FatArrow    // =>
 	Question    // ?
+	Coalesce    // ??
+	SafeDot     // ?.
 
 	// Delimiters.
 	Comma
@@ -160,6 +162,8 @@ var names = [...]string{
 	Arrow:       "->",
 	FatArrow:    "=>",
 	Question:    "?",
+	Coalesce:    "??",
+	SafeDot:     "?.",
 
 	Comma:      ",",
 	LParen:     "(",

--- a/testdata/semantics/control/block-expression.ari
+++ b/testdata/semantics/control/block-expression.ari
@@ -1,0 +1,25 @@
+// Everything in Aria is expression-valued except a block, which was the one
+// place the claim was not true. `do ... end` yields its last value and has its
+// own scope.
+let x = do
+  let a = 21
+  a * 2
+end
+println(x)
+
+// Its own scope: what it declares does not outlive it.
+let outer = "kept"
+let y = do
+  let outer = "shadowed"
+  outer
+end
+println(y)
+println(outer)
+
+// It nests, and an empty one is nil like any other empty body.
+println(do
+  do
+    "inner"
+  end
+end)
+println(do end)

--- a/testdata/semantics/control/block-expression.out
+++ b/testdata/semantics/control/block-expression.out
@@ -1,0 +1,6 @@
+42
+shadowed
+kept
+inner
+nil
+--- exit: 0

--- a/testdata/semantics/operators/nil-coalescing.ari
+++ b/testdata/semantics/operators/nil-coalescing.ari
@@ -1,0 +1,30 @@
+// Reading a missing key or index yields nil rather than failing, so threading
+// nil is an ordinary thing to be doing in Aria — but the only way to supply a
+// default was a ternary that named the subject twice, because `||` coerces to
+// Bool and `0 || 5` is true rather than 0.
+let cfg = [:host => "example.com", :retries => 0]
+println(cfg["port"] ?? 8080)
+println(cfg[:host] ?? "localhost")
+
+// nil, not falsy. That is the whole point of having it alongside `||`.
+println(cfg[:retries] ?? 3)
+println(0 ?? 5)
+println(0 || 5)
+println("" ?? "fallback")
+println(false ?? true)
+println(nil ?? "fallback")
+
+// It short-circuits, so the default is not evaluated when the left side is
+// there.
+var evaluated = 0
+let fallback = func () do
+  evaluated += 1
+  "computed"
+end
+println("present" ?? fallback())
+println(evaluated)
+println(nil ?? fallback())
+println(evaluated)
+
+// It binds tighter than || and looser than &&.
+println(nil ?? false || true)

--- a/testdata/semantics/operators/nil-coalescing.out
+++ b/testdata/semantics/operators/nil-coalescing.out
@@ -1,0 +1,14 @@
+8080
+example.com
+0
+0
+true
+
+false
+fallback
+present
+0
+computed
+1
+true
+--- exit: 0

--- a/testdata/semantics/operators/safe-navigation.ari
+++ b/testdata/semantics/operators/safe-navigation.ari
@@ -1,0 +1,13 @@
+// `?.` yields nil as soon as a link is nil, instead of failing on the next
+// access.
+let cfg = [:db => [:host => "localhost"]]
+println(cfg.db.host)
+println(cfg?.db?.host)
+println(cfg?.missing?.host)
+println(cfg?.db?.missing)
+println(cfg?.missing ?? "default")
+
+// The scanner absorbs a trailing `?` into a name — `empty?` is one token — but
+// not when a dot follows, or `cfg?.db` would read as a name called `cfg?`.
+println(Enum.empty?([]))
+println(Enum.empty?([1]))

--- a/testdata/semantics/operators/safe-navigation.out
+++ b/testdata/semantics/operators/safe-navigation.out
@@ -1,0 +1,8 @@
+localhost
+localhost
+nil
+nil
+default
+true
+false
+--- exit: 0


### PR DESCRIPTION
Three self-contained expression-level additions. Reading a missing key or index yields `nil` rather than failing, so threading nil is ordinary in Aria — and there was nothing to do it with. `||` can't substitute because it coerces: `0 || 5` is `true`, not `0`.

## What changed

- **`a ?? b`** yields `a` unless it is `nil`, and short-circuits. It tests for `nil` specifically rather than for truthiness, which is the whole point of having it alongside `||`. Binds tighter than `||`, looser than `&&`.
- **`a?.b`** yields `nil` as soon as a link is `nil`, and answers `nil` for a missing key too — subscripting already answers `nil` for the same read.
- That needed care in the scanner, which absorbs a trailing `?` into a name so `empty?` is one token. The rule is now "a trailing `?` belongs to the name unless a dot follows", which makes `empty?.x` unwritable as a member access on the result of `empty?` — parenthesise it. That's the side of the ambiguity worth losing, since the other is every safe navigation there is.
- **`do ... end` is an expression** with its own scope, yielding its last value. Everything in Aria is expression-valued except a block, which was the one place the claim wasn't true.
- `operators/nil-coalescing`, `operators/safe-navigation` and `control/block-expression` added, plus Go tests. Precedence table and both docs updated; `FuzzScan` and `FuzzParse` each run for 35s.

No existing golden changed.

Closes #22