### PR TITLE
A REPL that reads constructs, and check, -e and stdin for the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,26 @@ To run an Aria source file, give it a path relative to the current directory.
 aria run path/to/file.ari
 ```
 
+A `-` reads from standard input, so aria can sit in a pipeline:
+
+```
+cat path/to/file.ari | aria run -
+```
+
+### Run a one-liner
+
+```
+aria -e 'println(1 + 2)'
+```
+
+### Check without running
+
+`check` takes a file through the whole pipeline except evaluation — parse, then resolve — and exits non-zero if anything is wrong. That is what CI or an editor wants, and it catches everything the resolver knows: undefined names, immutable rebinding, unknown type hints, mistyped module members.
+
+```
+aria check path/to/file.ari
+```
+
 ### REPL
 
 As any serious language, Aria provides a REPL too:
@@ -88,6 +108,10 @@ As any serious language, Aria provides a REPL too:
 ```
 aria repl
 ```
+
+It reads whole constructs, not lines, so a multi-line `func`, `module`, `if` or `for` can be typed straight in — the prompt changes to `..` while one is still open, and an empty line abandons it. A statement that produced nothing prints nothing.
+
+`:help` lists the commands: `:load` evaluates a file into the session, `:vars` and `:modules` show what is in scope, and `:quit` leaves.
 
 ## Variables
 

--- a/aria.go
+++ b/aria.go
@@ -3,11 +3,15 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
+	"io"
 	"os"
+	"strings"
 
 	"github.com/fadion/aria/internal/interp"
 	"github.com/fadion/aria/internal/source"
+	"github.com/fadion/aria/internal/value"
 	"github.com/fatih/color"
 	"github.com/urfave/cli"
 )
@@ -24,12 +28,35 @@ func main() {
 	}}
 	app.Version = version
 
+	app.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:  "eval, e",
+			Usage: "Evaluate `SOURCE` and exit",
+		},
+	}
+
+	// A bare `aria -e '...'` has no subcommand, so the evaluation runs here.
+	// Without a -e, the default help is what an argument-less invocation wants.
+	app.Action = func(c *cli.Context) error {
+		if src := c.String("eval"); src != "" {
+			runSource(source.NewFile("-e", []byte(src)))
+			return nil
+		}
+		return cli.ShowAppHelp(c)
+	}
+
 	app.Commands = []cli.Command{
 		{
 			Name:      "run",
-			Usage:     "Run an Aria source file",
+			Usage:     "Run an Aria source file, or - for standard input",
 			ArgsUsage: "FILE",
 			Action:    runFile,
+		},
+		{
+			Name:      "check",
+			Usage:     "Parse and resolve without running, for CI or an editor",
+			ArgsUsage: "FILE",
+			Action:    checkFile,
 		},
 		{
 			Name:   "repl",
@@ -49,29 +76,54 @@ func main() {
 	}
 }
 
-func runFile(c *cli.Context) error {
+// readSource reads one argument as a source file. `-` is standard input, so
+// aria can sit in a pipeline.
+func readSource(c *cli.Context, command string) *source.File {
 	args := c.Args()
 	if len(args) != 1 {
 		// The original printed this and then indexed the empty argument list,
 		// panicking with an index-out-of-range.
-		color.Red("Run expects exactly one source file.")
+		color.Red("%s expects exactly one source file.", command)
 		os.Exit(2)
 	}
 
 	path := args[0]
+	if path == "-" {
+		src, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			color.Red("Couldn't read standard input")
+			os.Exit(1)
+		}
+		return source.NewFile("<stdin>", src)
+	}
+
 	src, err := os.ReadFile(path)
 	if err != nil {
 		color.Red("Couldn't read '%s'", path)
 		os.Exit(1)
 	}
+	return source.NewFile(path, src)
+}
 
-	if !interp.Run(source.NewFile(path, src), interp.Options{
+func runFile(c *cli.Context) error {
+	runSource(readSource(c, "Run"))
+	return nil
+}
+
+func runSource(file *source.File) {
+	if !interp.Run(file, interp.Options{
 		Out: os.Stdout,
 		Err: os.Stderr,
 		In:  os.Stdin,
 	}) {
 		// A failed run exits non-zero, so a script or CI can tell. The original
 		// exited 0 on every parse and runtime error alike.
+		os.Exit(1)
+	}
+}
+
+func checkFile(c *cli.Context) error {
+	if !interp.Check(readSource(c, "Check"), interp.Options{Err: os.Stderr}) {
 		os.Exit(1)
 	}
 	return nil
@@ -83,7 +135,7 @@ func runREPL(c *cli.Context) error {
   / _ \|   /| | / _ \
  /_/ \_\_|_\___/_/ \_\
  `)
-	color.White("Close by pressing CTRL+C")
+	color.White("Type :help for the commands, or press CTRL+C to leave")
 	fmt.Println()
 
 	session, err := interp.NewSession(interp.Options{
@@ -97,29 +149,104 @@ func runREPL(c *cli.Context) error {
 	}
 
 	input := bufio.NewScanner(os.Stdin)
+
+	// buffered holds the lines of a construct still being typed. Reading one
+	// line at a time meant a multi-line func, module, if or for could not be
+	// entered at all, which is most of what a REPL is for.
+	var buffered []string
+
 	for {
+		prompt := ">> "
+		if len(buffered) > 0 {
+			prompt = ".. "
+		}
 		color.Set(color.FgWhite)
-		fmt.Print(">> ")
+		fmt.Print(prompt)
 		color.Unset()
 
 		if !input.Scan() {
 			fmt.Println()
 			return nil
 		}
-
 		line := input.Text()
-		if line == "" {
+
+		// An empty line abandons a half-typed construct, which is the way out
+		// of one that can never be completed.
+		if strings.TrimSpace(line) == "" {
+			buffered = nil
 			continue
 		}
 
-		v, err := session.Eval(line)
+		if len(buffered) == 0 {
+			if done, handled := replCommand(session, line); handled {
+				if done {
+					return nil
+				}
+				continue
+			}
+		}
+
+		buffered = append(buffered, line)
+		v, err := session.Eval(strings.Join(buffered, "\n"))
+		if errors.Is(err, interp.ErrIncomplete) {
+			continue
+		}
+		buffered = nil
+
 		if err != nil {
 			// A failed line leaves the session intact, so a typo does not end it.
 			color.Red("%s", err)
 			continue
 		}
-		if v != nil {
+		// A statement that produced nothing prints nothing. Half a session used
+		// to be `nil` from println calls.
+		if v != nil && v != value.NilValue {
 			fmt.Println(v.Inspect())
 		}
 	}
+}
+
+// replCommand handles a `:` command, reporting whether it handled the line and
+// whether the session should end.
+func replCommand(session *interp.Session, line string) (done, handled bool) {
+	fields := strings.Fields(line)
+	if len(fields) == 0 || !strings.HasPrefix(fields[0], ":") {
+		return false, false
+	}
+
+	switch fields[0] {
+	case ":help":
+		color.White(":help          this list")
+		color.White(":load FILE     evaluate a file into this session")
+		color.White(":vars          the names declared so far")
+		color.White(":modules       the modules in scope")
+		color.White(":quit          leave")
+	case ":quit", ":exit":
+		return true, true
+	case ":vars":
+		names := session.Declared()
+		if len(names) == 0 {
+			color.White("nothing declared yet")
+			break
+		}
+		color.White("%s", strings.Join(names, ", "))
+	case ":modules":
+		color.White("%s", strings.Join(session.Modules(), ", "))
+	case ":load":
+		if len(fields) != 2 {
+			color.Red(":load expects a file")
+			break
+		}
+		src, err := os.ReadFile(fields[1])
+		if err != nil {
+			color.Red("Couldn't read '%s'", fields[1])
+			break
+		}
+		if _, err := session.Eval(string(src)); err != nil {
+			color.Red("%s", err)
+		}
+	default:
+		color.Red("Unknown command %q. Try :help", fields[0])
+	}
+	return false, true
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -634,6 +634,35 @@ compared case by case. With it unset the runner uses a binary in the repo root i
 one, and otherwise builds a throwaway — so the suite runs from a clean checkout with no
 setup, and leaves nothing behind.
 
+## The tools
+
+`run`, `check`, `repl`, and `-e` for a one-liner. `run -` reads standard input.
+
+`check` is the pipeline stopped after resolution, which is what `Run` already did internally
+before evaluating anything. It catches everything the resolver knows — undefined names,
+immutable rebinding, unknown type hints, mistyped module members — without the program
+having any effect, which is what CI or an editor integration wants.
+
+**The REPL reads constructs, not lines.** A session that takes one line at a time cannot
+accept a multi-line `func`, `module`, `if` or `for` at all, which rules out most of what a
+REPL is for. `Session.Eval` takes a whole fragment and answers `ErrIncomplete` when more
+input could complete it, so the REPL buffers until it parses.
+
+Incompleteness is a flag on the `diag.Bag`, not a string match on the message. The parser
+sets it when it reports its first diagnostic while sitting at end of input: that means it
+ran out of source with a construct still open, rather than that it found something wrong.
+An unterminated raw string and an unterminated block comment set it from the scanner, since
+both may span lines; an unterminated `"` string does not, since it may not.
+
+**Nothing prints for a statement that produced nothing.** Half a session used to be `nil`
+from `println` calls.
+
+**There is no `fmt`.** A formatter is a separate project rather than a missing subcommand:
+it needs a decision about every layout question in the language, and where a line may break
+was only settled above. `scanner.ScanComments` stays, because the fuzzer runs the scanner in
+both modes and so the mode is covered code rather than speculative code. `token.IsKeyword`
+went, because nothing called it and nothing covered it.
+
 ## Testing
 
 - Unit tests per package.

--- a/internal/diag/diag.go
+++ b/internal/diag/diag.go
@@ -54,6 +54,11 @@ type Bag struct {
 	list   []Diagnostic
 	max    int
 	capped bool
+	// incomplete records that something ran off the end of the input with a
+	// construct still open. It is what lets a REPL tell "keep typing" from
+	// "wrong", which is not something the message text should have to be
+	// matched against.
+	incomplete bool
 }
 
 // New returns a Bag for file, keeping at most DefaultMax diagnostics.
@@ -89,6 +94,13 @@ func (b *Bag) add(sev Severity, span source.Span, format string, args ...any) {
 		Message:  fmt.Sprintf(format, args...),
 	})
 }
+
+// MarkIncomplete records that the input ended with a construct still open.
+func (b *Bag) MarkIncomplete() { b.incomplete = true }
+
+// Incomplete reports whether more input could make this parse. It stays false
+// once anything else has gone wrong, since more input cannot fix that.
+func (b *Bag) Incomplete() bool { return b.incomplete && b.Len() == 1 }
 
 // HasErrors reports whether any diagnostic is an error.
 func (b *Bag) HasErrors() bool {

--- a/internal/interp/run.go
+++ b/internal/interp/run.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 
 	"github.com/fadion/aria/internal/ast"
@@ -57,11 +58,14 @@ func Run(file *source.File, opts Options) bool {
 		}
 	}
 
+	// Globals first, then modules: predeclaring a name replaces its binding, and
+	// a module's binding is the one its member list is attached to. A module IS
+	// a global, so the other order silently dropped the member checking.
 	r := resolver.New(file, bag)
-	i.predeclareModules(r)
 	for name := range i.globals.vars {
 		r.Predeclare(name)
 	}
+	i.predeclareModules(r)
 	info := r.Resolve(prog)
 	if bag.HasErrors() {
 		fmt.Fprint(opts.Err, bag.Render())
@@ -76,6 +80,44 @@ func Run(file *source.File, opts Options) bool {
 			return false
 		}
 		i.Report(re)
+		return false
+	}
+	return true
+}
+
+// Check compiles file without evaluating it, reporting into Options.Err.
+//
+// It is the same pipeline Run uses, stopped after resolution — which is what an
+// editor or a CI step wants, and what Run already did internally before
+// evaluating anything.
+func Check(file *source.File, opts Options) bool {
+	if opts.Err == nil {
+		panic("interp.Check: Err is required")
+	}
+
+	bag := diag.New(file)
+	prog := parser.New(file, bag).Parse()
+	if bag.HasErrors() {
+		fmt.Fprint(opts.Err, bag.Render())
+		return false
+	}
+
+	// The standard library has to be loaded, not just named: resolution checks
+	// module members, and those are only known once it has been evaluated.
+	i := New(file, nil)
+	i.Out, i.Err, i.In = io.Discard, opts.Err, strings.NewReader("")
+	if !opts.NoStdlib && !i.loadStdlib(opts.Err) {
+		return false
+	}
+
+	r := resolver.New(file, bag)
+	for name := range i.globals.vars {
+		r.Predeclare(name)
+	}
+	i.predeclareModules(r)
+	r.Resolve(prog)
+	if bag.HasErrors() {
+		fmt.Fprint(opts.Err, bag.Render())
 		return false
 	}
 	return true
@@ -172,10 +214,10 @@ func Eval(name, src string, opts Options) (value.Value, error) {
 	}
 
 	r := resolver.New(file, bag)
-	i.predeclareModules(r)
 	for n := range i.globals.vars {
 		r.Predeclare(n)
 	}
+	i.predeclareModules(r)
 	info := r.Resolve(prog)
 	if bag.HasErrors() {
 		return nil, fmt.Errorf("%s", bag.Render())
@@ -210,6 +252,27 @@ type Session struct {
 	line     int
 }
 
+// Declared lists the names earlier fragments introduced, in sorted order, so a
+// REPL can show what is in scope.
+func (s *Session) Declared() []string {
+	out := make([]string, 0, len(s.declared))
+	for name := range s.declared {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Modules lists the modules in scope, standard library included.
+func (s *Session) Modules() []string {
+	out := make([]string, 0, len(s.interp.modules))
+	for name := range s.interp.modules {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
 // NewSession starts a session with the standard library loaded.
 func NewSession(opts Options) (*Session, error) {
 	file := source.NewFile("<repl>", nil)
@@ -235,8 +298,17 @@ func NewSession(opts Options) (*Session, error) {
 	return &Session{interp: i, declared: map[string]bool{}}, nil
 }
 
-// Eval runs one line. It returns the line's value, or an error describing why it
+// ErrIncomplete says the source given to Session.Eval opened a construct it did
+// not close, so more input could complete it. A REPL buffers on this rather than
+// reporting it.
+var ErrIncomplete = errors.New("incomplete input")
+
+// Eval runs one fragment. It returns its value, or an error describing why it
 // could not run — already formatted with a caret, as a file would be.
+//
+// A REPL that reads one line at a time cannot enter a multi-line func, module,
+// if or for at all, which rules out most of what a REPL is for. Eval takes a
+// whole fragment and says ErrIncomplete when more input could complete it.
 func (s *Session) Eval(src string) (value.Value, error) {
 	s.line++
 	file := source.NewFile(fmt.Sprintf("<repl:%d>", s.line), []byte(src))
@@ -244,6 +316,12 @@ func (s *Session) Eval(src string) (value.Value, error) {
 
 	prog := parser.New(file, bag).Parse()
 	if bag.HasErrors() {
+		if bag.Incomplete() {
+			// The fragment opened something it did not close. A REPL reads this
+			// as "keep typing" rather than as a mistake.
+			s.line--
+			return nil, ErrIncomplete
+		}
 		return nil, fmt.Errorf("%s", strings.TrimRight(bag.Render(), "\n"))
 	}
 

--- a/internal/interp/session_test.go
+++ b/internal/interp/session_test.go
@@ -1,0 +1,156 @@
+package interp_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/fadion/aria/internal/interp"
+	"github.com/fadion/aria/internal/source"
+	"github.com/fadion/aria/internal/value"
+)
+
+func newSession(t *testing.T, out *strings.Builder) *interp.Session {
+	t.Helper()
+	s, err := interp.NewSession(interp.Options{
+		Out: out, Err: out, In: strings.NewReader(""),
+	})
+	if err != nil {
+		t.Fatalf("starting a session: %v", err)
+	}
+	return s
+}
+
+// A REPL reading one line at a time cannot enter a multi-line func, module, if
+// or for at all, which is most of what a REPL is for. Eval says ErrIncomplete
+// when more input could complete the fragment.
+func TestSessionIncompleteInput(t *testing.T) {
+	var out strings.Builder
+	s := newSession(t, &out)
+
+	incomplete := []string{
+		"let f = func (x) do",
+		"let f = func (x) do\n  x * 2",
+		"if true",
+		"for i in 1..3",
+		"module M",
+		"switch 1\ncase 1 then 2",
+		"let a = [",
+		"let s = `unterminated",
+	}
+	for _, src := range incomplete {
+		if _, err := s.Eval(src); !errors.Is(err, interp.ErrIncomplete) {
+			t.Errorf("%q: got %v, want ErrIncomplete", src, err)
+		}
+	}
+
+	// Something actually wrong is not incomplete. `println(` is not in this
+	// list on purpose: a call's arguments may span lines, so it genuinely is
+	// unfinished rather than wrong.
+	for _, src := range []string{"let 1 = 2", "let a = )", `let s = "unterminated`} {
+		if _, err := s.Eval(src); errors.Is(err, interp.ErrIncomplete) {
+			t.Errorf("%q: reported incomplete, expected a real error", src)
+		}
+	}
+}
+
+// Buffering until it parses is what a REPL does with ErrIncomplete, and the
+// completed fragment has to run as one unit.
+func TestSessionMultiLineConstructs(t *testing.T) {
+	var out strings.Builder
+	s := newSession(t, &out)
+
+	fragment := "let double = func (x) do\n  x * 2\nend"
+	if _, err := s.Eval(fragment); err != nil {
+		t.Fatalf("%q: %v", fragment, err)
+	}
+
+	v, err := s.Eval("double(21)")
+	if err != nil {
+		t.Fatalf("calling it back: %v", err)
+	}
+	if v.String() != "42" {
+		t.Errorf("got %s, want 42", v)
+	}
+
+	// A name declared across lines is carried forward like any other.
+	if _, err := s.Eval("module M\n  let a = 1\nend"); err != nil {
+		t.Fatalf("declaring a module: %v", err)
+	}
+	if v, err := s.Eval("M.a"); err != nil || v.String() != "1" {
+		t.Errorf("got %v, %v; want 1", v, err)
+	}
+}
+
+// A statement that produced nothing has nothing to print: half a session used to
+// be `nil` from println calls.
+func TestSessionNilResults(t *testing.T) {
+	var out strings.Builder
+	s := newSession(t, &out)
+
+	v, err := s.Eval(`println("hi")`)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	if v != value.NilValue {
+		t.Errorf("println returned %v, want nil", v)
+	}
+	if out.String() != "hi\n" {
+		t.Errorf("printed %q", out.String())
+	}
+}
+
+func TestSessionIntrospection(t *testing.T) {
+	var out strings.Builder
+	s := newSession(t, &out)
+
+	if names := s.Declared(); len(names) != 0 {
+		t.Errorf("a fresh session declares %v", names)
+	}
+	if _, err := s.Eval("let a = 1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Eval("var b = 2"); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(s.Declared(), ","); got != "a,b" {
+		t.Errorf("got %q, want a,b", got)
+	}
+
+	mods := strings.Join(s.Modules(), ",")
+	for _, want := range []string{"Enum", "String", "Math", "Dict", "Type"} {
+		if !strings.Contains(mods, want) {
+			t.Errorf("%s missing from %q", want, mods)
+		}
+	}
+}
+
+// Check runs the pipeline as far as resolution and no further, which is what an
+// editor or a CI step wants.
+func TestCheckDoesNotEvaluate(t *testing.T) {
+	var out strings.Builder
+	file := source.NewFile("test.ari", []byte(`println("SHOULD NOT PRINT")`))
+	if !interp.Check(file, interp.Options{Err: &out}) {
+		t.Errorf("a valid file failed to check:\n%s", out.String())
+	}
+	if out.Len() != 0 {
+		t.Errorf("check wrote %q", out.String())
+	}
+
+	// A name error is caught without anything running.
+	out.Reset()
+	bad := source.NewFile("test.ari", []byte("println(nope)"))
+	if interp.Check(bad, interp.Options{Err: &out}) {
+		t.Error("an undefined name passed the check")
+	}
+	if !strings.Contains(out.String(), "'nope' is not defined") {
+		t.Errorf("check reported %q", out.String())
+	}
+
+	// So is a runtime-only mistake that the resolver can see.
+	out.Reset()
+	typo := source.NewFile("test.ari", []byte("println(Enum.sizze([1]))"))
+	if interp.Check(typo, interp.Options{Err: &out}) {
+		t.Error("a mistyped module member passed the check")
+	}
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -236,6 +236,13 @@ func (p *Parser) errorAt(span source.Span, format string, args ...any) {
 		return
 	}
 	p.panicking = true
+	// Reporting while sitting at end of input means the parser ran out, not
+	// that it found something wrong: a construct is still open and more source
+	// could close it. That is what lets a REPL tell "keep typing" from "wrong"
+	// without matching on the message text.
+	if p.at(token.EOF) {
+		p.diags.MarkIncomplete()
+	}
 	p.diags.Errorf(span, format, args...)
 }
 

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -536,6 +536,9 @@ func (s *Scanner) scanRawString(start source.Pos) token.Token {
 	for {
 		switch s.ch {
 		case eof:
+			// A raw string spans lines, so running out of input with one open
+			// means more input could close it.
+			s.diags.MarkIncomplete()
 			s.diags.Errorf(source.Span{Start: start, End: s.off}, "unterminated raw string")
 			return s.token(token.Invalid, start)
 		case '`':
@@ -564,6 +567,7 @@ func (s *Scanner) scanBlockComment(start source.Pos) (token.Token, bool) {
 	for {
 		switch s.ch {
 		case eof:
+			s.diags.MarkIncomplete()
 			s.diags.Errorf(source.Span{Start: start, End: s.off}, "unterminated block comment")
 			return s.token(token.Invalid, start), true
 		case '*':

--- a/internal/token/token.go
+++ b/internal/token/token.go
@@ -84,9 +84,7 @@ const (
 	Dot        // .
 	Underscore // _
 
-	// Keywords. keywordStart and keywordEnd bracket this run so IsKeyword is
-	// a range check; keep every keyword between them.
-	keywordStart
+	// Keywords.
 	Let
 	Var
 	Func
@@ -109,7 +107,6 @@ const (
 	Continue
 	Module
 	Import
-	keywordEnd
 )
 
 // names is indexed by Kind. Entries for operators and delimiters are the
@@ -208,9 +205,6 @@ func (k Kind) String() string {
 	}
 	return "unknown token"
 }
-
-// IsKeyword reports whether k is a reserved word.
-func (k Kind) IsKeyword() bool { return k > keywordStart && k < keywordEnd }
 
 // keywords maps reserved words to their kind. It is written once here and only
 // ever read afterwards, so it is safe to share across concurrent scanners —


### PR DESCRIPTION
The REPL scanned one line at a time, so a multi-line `func`, `module`, `if` or `for` could not be entered at all — most of what a REPL is for. And it printed the value of every line, so half a session was `nil` from `println` calls.

## What changed

- **`Session.Eval` takes a whole fragment** and answers `ErrIncomplete` when more input could complete it. The REPL buffers until it parses, shows `..` while a construct is open, and abandons one on an empty line.
- **Incompleteness is a flag on the `diag.Bag`**, not a string match on the message. The parser sets it when it reports its first diagnostic while sitting at end of input — it ran out of source with a construct open, rather than finding something wrong. An unterminated raw string or block comment sets it from the scanner too, since both may span lines; an unterminated `"` string does not.
- **Nothing prints for a statement that produced nothing.** Plus `:help`, `:load`, `:vars`, `:modules`, `:quit`. History still needs a line editor, which needs a dependency.
- **`aria check FILE`** — the pipeline stopped after resolution, exiting non-zero on any diagnostic. **`aria -e 'expr'`** for a one-liner. **`aria run -`** for standard input.
- **A bug this found**: `Run` predeclared modules and *then* every global — and a module is a global, so the second pass replaced the binding its member list was attached to and the member checking from #17 silently did nothing. Invisible, because the evaluator's message for the same mistake is identical. Globals are predeclared first now, in all four places that build a resolver.
- **The `fmt` decision: not now.** A formatter needs a ruling on every layout question in the language, and where a line may break was only settled in #10. `ScanComments` stays — the fuzzer runs the scanner in both modes, so it is covered rather than speculative. `token.IsKeyword` goes: nothing called it and nothing covered it.
- `internal/interp/session_test.go` covers `Session` across multi-line input and `Check`.

No golden changed.

Closes #29