### PR TITLE
switch guards, type cases, range cases, and one meaning for a case list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ go test ./internal/parser/  -run=Fuzz -fuzz=FuzzParse -fuzztime=30s
 
 ## The characterization suite is the arbiter
 
-`testdata/semantics/` holds 189 `.ari` files, each with a `.out` golden recording exactly
+`testdata/semantics/` holds 193 `.ari` files, each with a `.out` golden recording exactly
 what the interpreter prints and what it exits with.
 
 **If a golden changes, you changed the language.** That is either the point of your change

--- a/README.md
+++ b/README.md
@@ -943,33 +943,63 @@ default
 end
 ```
 
+### Guards, Types and Ranges
+
+A `when` clause guards an arm. It's tested only once one of the arm's values has already matched, which is what lets the control-less form replace an else-if chain without repeating the subject:
+
+```swift
+let describe = func (n)
+  switch n
+  case 1..9 when n % 2 == 0 then "even digit"
+  case 1..9 then "odd digit"
+  default then "not a digit"
+  end
+end
+println(describe(4))
+```
+
+`is` works in case position, matching on the control's type. A range matches membership:
+
+```swift
+let classify = func (v)
+  switch v
+  case is Int then "a number"
+  case is String then "some text"
+  case is Any then "something else"
+  end
+end
+println(classify("hi"))
+```
+
+A guard that fails falls through to the next arm rather than to `default`.
+
 ### Pattern Matching
 
-When fed arrays as the control condition, the `switch` can pattern match its elements. Every argument to the switch case is compared to the respective element of the array. Off course, for a match, the number of arguments should match the size of the array.
+An array literal in case position pattern matches its elements. For a match, the pattern and the array have to be the same size:
 
 ```swift
 switch ["game", "of", "thrones"]
-case "game", "thrones"
+case ["game", "thrones"]
   println("no match")
-case "game", "of", "thrones"
+case ["game", "of", "thrones"]
   println("yep!")
 end
 ```
 
-That's probably useful from time to time, but it's totally achievable with array cases. The `switch` can do much better than that.
+The `_` is a placeholder that will match any type and value, so you can compare arrays where you don't need to know every element:
 
 ```swift
 switch ["John", "Lick", 2]
-case "John", _, _
+case ["John", _, _]
   println("John Something")
-case _, _ 2
+case [_, _, 2]
   println("Something 2")
 default
   println("Lame movie pun not found")
 end
 ```
 
-The `_` is a placeholder that will match any type and value. That makes it powerful to compare arrays where you don't need to know every element. You can mix and match values with placeholders in any position, as long as they match the size of the array.
+A comma-separated case list is a list of *alternatives*, not a pattern — `case 1, 2` means "1 or 2" whatever the control is. That distinction is why a pattern gets the array-literal spelling: the same syntax used to mean both, chosen by the runtime type of the subject.
 
 ## For Loop
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -502,6 +502,34 @@ spends a section on. A count needs no new token, where a label would; it reads p
 two, but two is the case that comes up. The resolver counts the loops a `break` is inside,
 so `break 3` inside two is a diagnostic rather than an unwind out of the enclosing function.
 
+## A case list is alternatives; a pattern is an array literal
+
+`case 1, 2` used to mean "1 or 2" for a scalar control and "the array `[1, 2]`" for an
+array control — one syntax with two meanings, chosen by the runtime type of the subject.
+Both were documented in the README as features.
+
+A comma-separated list is always a list of alternatives. A pattern is written as an array
+literal, `case [1, _]`, which the parser can already tell apart, and `_` inside one is a
+wildcard for that element. A pattern of a different arity is simply a different array. A
+bare `_` among alternatives is still the match-anything wildcard, which is `default` said
+in an arm.
+
+That leaves `switch` able to carry the weight the README gives it — it is the language's
+stated answer to the missing `else if` — with three additions:
+
+**`when` guards.** Tested only once one of the arm's values has matched, so the
+control-less form replaces an else-if chain without repeating the subject. A guard that
+fails falls through to the next arm rather than to `default`.
+
+**`case is Type`.** Aria already has `is` as an operator; this is it where there is no
+left-hand side to write, which was the most common reason to reach for a chain of `typeof`
+comparisons. The type name is checked at resolve time, so a typo is a diagnostic rather
+than an arm that never matches.
+
+**`case a..b`.** Membership, not equality. An `Int` range is tested by comparison, so
+`case 1..1000000` costs nothing; anything else materialises, which is what `..` does outside
+a case anyway.
+
 ## Nil is threaded, not tested for truth
 
 Reading a missing array index or dictionary key yields `nil` rather than failing, so
@@ -606,7 +634,7 @@ something the author of an Aria program can act on.
 
 ## The characterization suite
 
-`testdata/semantics/` holds 189 cases. Each `.ari` file has a `.out` golden recording
+`testdata/semantics/` holds 193 cases. Each `.ari` file has a `.out` golden recording
 exactly what the interpreter prints and what it exits with.
 
 ```bash

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -339,12 +339,30 @@ func (n *If) Inspect() string {
 type SwitchCase struct {
 	Base
 	Values *ExpressionList
-	Body   *Block
+	// Guard is a `when` clause, tested only once a value has already matched.
+	// It is what lets the control-less form replace an else-if chain without
+	// repeating the subject.
+	Guard Node
+	Body  *Block
 }
 
 func (n *SwitchCase) Inspect() string {
-	return "case " + n.Values.Inspect() + " then " + n.Body.Inspect()
+	out := "case " + n.Values.Inspect()
+	if n.Guard != nil {
+		out += " when " + n.Guard.Inspect()
+	}
+	return out + " then " + n.Body.Inspect()
 }
+
+// TypeCase is `case is Type`, which matches on the control's type rather than
+// its value. Aria already has `is` as an operator; this is it in case position,
+// where there is no left-hand side to write.
+type TypeCase struct {
+	Base
+	Name *Identifier
+}
+
+func (n *TypeCase) Inspect() string { return "is " + n.Name.Inspect() }
 
 // Switch is a multi-way branch. Control is nil for the control-less form, which
 // behaves as `switch true`.

--- a/internal/ast/walk.go
+++ b/internal/ast/walk.go
@@ -108,7 +108,10 @@ func Children(n Node) []Node {
 		block(n.Default)
 	case *SwitchCase:
 		list(n.Values)
+		node(n.Guard)
 		block(n.Body)
+	case *TypeCase:
+		ident(n.Name)
 	case *For:
 		if n.Arguments != nil {
 			for _, e := range n.Arguments.Elements {

--- a/internal/interp/interp.go
+++ b/internal/interp/interp.go
@@ -729,30 +729,98 @@ func (i *Interp) evalSwitch(n *ast.Switch, e *env) value.Value {
 	return value.NilValue
 }
 
-// caseMatches reports whether a case arm matches the control value. An array
-// control pattern-matches element by element, with `_` as a wildcard.
+// caseMatches reports whether a case arm matches the control value.
+//
+// A comma-separated list is always a list of alternatives. It used to mean that
+// for a scalar control and "the array [1, 2]" for an array control, chosen by
+// the runtime type of the subject — one syntax with two meanings. A pattern is
+// written as an array literal now, `case [1, _]`, which is a spelling the parser
+// can already tell apart.
 func (i *Interp) caseMatches(c *ast.SwitchCase, control value.Value, e *env) bool {
-	// An array control with a matching arity is pattern-matched element by
-	// element, and that answer is final. Falling through to scalar matching
-	// afterwards would let a `_` anywhere in the pattern match everything.
-	if arr, ok := control.(*value.Array); ok && len(c.Values.Elements) == arr.Len() {
-		for idx, el := range c.Values.Elements {
-			if _, wild := el.(*ast.Placeholder); wild {
+	matched := false
+	for _, el := range c.Values.Elements {
+		if i.caseValueMatches(el, control, e) {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		return false
+	}
+
+	// The guard is tested only once a value has matched, so it may lean on
+	// whatever the match established.
+	if c.Guard != nil {
+		return value.Truthy(i.eval(c.Guard, e))
+	}
+	return true
+}
+
+func (i *Interp) caseValueMatches(el ast.Node, control value.Value, e *env) bool {
+	switch el := el.(type) {
+	case *ast.Placeholder:
+		// A bare `_` matches anything, which is `default` said in an arm.
+		return true
+
+	case *ast.TypeCase:
+		if el.Name.Value == value.Any {
+			return true
+		}
+		return control.Type().String() == el.Name.Value
+
+	case *ast.Array:
+		// An array literal in case position pattern-matches element by element,
+		// with `_` as a wildcard. Only when the arities agree: a shorter or
+		// longer pattern is simply a different array.
+		arr, ok := control.(*value.Array)
+		if !ok || arr.Len() != len(el.List.Elements) {
+			return false
+		}
+		for idx, item := range el.List.Elements {
+			if _, wild := item.(*ast.Placeholder); wild {
 				continue
 			}
-			if !value.Equal(i.eval(el, e), arr.At(idx)) {
+			if !value.Equal(i.eval(item, e), arr.At(idx)) {
 				return false
 			}
 		}
 		return true
+
+	case *ast.Infix:
+		// A range case tests membership rather than equality, which is what
+		// `case 1..9` reads as.
+		if el.Operator == ".." {
+			return i.inRange(i.eval(el.Left, e), i.eval(el.Right, e), control, el.Span())
+		}
 	}
 
-	for _, el := range c.Values.Elements {
-		if _, wild := el.(*ast.Placeholder); wild {
-			return true
+	return value.Equal(i.eval(el, e), control)
+}
+
+// inRange reports whether control falls inside from..to.
+//
+// An Int range is tested by comparison, so `case 1..1000000` costs nothing.
+// Anything else materialises, which is what `..` does outside a case anyway.
+func (i *Interp) inRange(from, to, control value.Value, span source.Span) bool {
+	if a, isInt := from.(value.Int); isInt {
+		if b, isInt := to.(value.Int); isInt {
+			n, ok := control.(value.Int)
+			if !ok {
+				return false
+			}
+			lo, hi := int64(a), int64(b)
+			if lo > hi {
+				lo, hi = hi, lo
+			}
+			return int64(n) >= lo && int64(n) <= hi
 		}
-		if value.Equal(i.eval(el, e), control) {
-			return true
+	}
+
+	if arr, ok := i.applyInfix("..", from, to, span).(*value.Array); ok {
+		for _, v := range arr.Elems() {
+			if value.Equal(v, control) {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/interp/interp_test.go
+++ b/internal/interp/interp_test.go
@@ -421,11 +421,24 @@ func TestSwitch(t *testing.T) {
 	}
 }
 
+// A comma-separated case list is always a list of alternatives. It used to mean
+// that for a scalar control and "the array [1, 2]" for an array control, chosen
+// by the runtime type of the subject. A pattern is an array literal now.
 func TestSwitchPatternMatching(t *testing.T) {
 	tests := []struct{ src, want string }{
-		{"switch [1, 2] do case 1, 2 then 10 default then 20 end", "10"},
-		{"switch [1, 9] do case 1, _ then 10 default then 20 end", "10"},
-		{"switch [1, 9] do case 2, _ then 10 default then 20 end", "20"},
+		// Alternatives, so an array control equals neither.
+		{"switch [1, 2] do case 1, 2 then 10 default then 20 end", "20"},
+		{"switch 2 do case 1, 2 then 10 default then 20 end", "10"},
+
+		// The pattern spelling, with `_` as a wildcard inside it.
+		{"switch [1, 2] do case [1, 2] then 10 default then 20 end", "10"},
+		{"switch [1, 9] do case [1, _] then 10 default then 20 end", "10"},
+		{"switch [1, 9] do case [2, _] then 10 default then 20 end", "20"},
+		// A pattern of a different arity is simply a different array.
+		{"switch [1, 9] do case [1] then 10 default then 20 end", "20"},
+
+		// A bare `_` among alternatives is still the match-anything wildcard.
+		{"switch [1, 9] do case 2, _ then 10 default then 20 end", "10"},
 	}
 	for _, test := range tests {
 		if got := str(t, test.src); got != test.want {
@@ -1772,5 +1785,65 @@ func TestMultilineParameters(t *testing.T) {
 	// The bare form still works on one line.
 	if got := output(t, "let times = func a, b do a * b end\nprintln(times(3, 4))"); got != "12\n" {
 		t.Errorf("got %q", got)
+	}
+}
+
+// A `when` clause is tested only once one of the arm's values has matched, so
+// the control-less form replaces an else-if chain without repeating the subject.
+func TestSwitchGuards(t *testing.T) {
+	tests := []struct{ src, want string }{
+		{"switch 4 do case 1..9 when 4 % 2 == 0 then 10 default then 20 end", "10"},
+		{"switch 5 do case 1..9 when 5 % 2 == 0 then 10 default then 20 end", "20"},
+		// A guard that fails falls through to the next arm, not to default.
+		{"switch 5 do case 5 when false then 10 case 5 then 30 default then 20 end", "30"},
+		// And on the control-less form.
+		{"switch\ncase true when false then 10\ncase true then 30\nend", "30"},
+	}
+	for _, test := range tests {
+		if got := str(t, test.src); got != test.want {
+			t.Errorf("%s: got %s, want %s", test.src, got, test.want)
+		}
+	}
+}
+
+// `is` in case position matches on the control's type, which was the most
+// common reason to reach for a chain of typeof comparisons.
+func TestSwitchTypeCases(t *testing.T) {
+	tests := []struct{ src, want string }{
+		{`switch 1 do case is Int then "int" default then "no" end`, "int"},
+		{`switch "x" do case is String then "string" default then "no" end`, "string"},
+		{`switch [1] do case is Array then "array" default then "no" end`, "array"},
+		{`switch nil do case is Nil then "nil" default then "no" end`, "nil"},
+		{`switch 1.5 do case is Int then "int" case is Any then "any" end`, "any"},
+	}
+	for _, test := range tests {
+		if got := str(t, test.src); got != test.want {
+			t.Errorf("%s: got %s, want %s", test.src, got, test.want)
+		}
+	}
+
+	// The type name is checked, so a typo is a diagnostic rather than an arm
+	// that never matches.
+	fails(t, `println(switch 1 do case is Banana then 1 end)`, "'Banana' is not a type")
+}
+
+// A range in case position tests membership rather than equality.
+func TestSwitchRangeCases(t *testing.T) {
+	tests := []struct{ src, want string }{
+		{`switch 5 do case 1..9 then "digit" default then "no" end`, "digit"},
+		{`switch 42 do case 1..9 then "digit" case 10..99 then "two" default then "no" end`, "two"},
+		{`switch 0 do case 1..9 then "digit" default then "no" end`, "no"},
+		// A descending range covers the same span.
+		{`switch 5 do case 9..1 then "in" default then "out" end`, "in"},
+		// A character range materialises, which is what `..` does anyway.
+		{`switch "d" do case "a".."f" then "hex" default then "no" end`, "hex"},
+		{`switch "z" do case "a".."f" then "hex" default then "no" end`, "no"},
+		// An Int range is tested by comparison, so a huge one costs nothing.
+		{`switch 999999 do case 1..100000000 then "in" default then "out" end`, "in"},
+	}
+	for _, test := range tests {
+		if got := str(t, test.src); got != test.want {
+			t.Errorf("%s: got %s, want %s", test.src, got, test.want)
+		}
 	}
 }

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -1433,6 +1433,24 @@ func (p *Parser) parseParameter(fn *ast.Function, variadicSeen bool) (ast.Node, 
 }
 
 // parseSwitch reads `switch [control] cases... end`.
+// parseCaseValue reads one value of a case arm. `is Type` is only meaningful
+// here, where there is no left-hand side to write, so it is read here rather
+// than given a prefix parse that would be wrong everywhere else.
+func (p *Parser) parseCaseValue() ast.Node {
+	if !p.at(token.Is) {
+		return p.parseExpr(lowest)
+	}
+
+	start := p.tok.Span
+	if !p.expectPeek(token.Ident) {
+		return &ast.Bad{Base: ast.Base{Sp: start}, Text: "is"}
+	}
+	return &ast.TypeCase{
+		Base: ast.Base{Sp: span(start, p.tok.Span)},
+		Name: &ast.Identifier{Base: ast.Base{Sp: p.tok.Span}, Value: p.text(p.tok)},
+	}
+}
+
 func (p *Parser) parseSwitch() ast.Node {
 	start := p.tok.Span
 	node := &ast.Switch{Base: ast.Base{Sp: start}}
@@ -1459,7 +1477,7 @@ func (p *Parser) parseSwitch() ast.Node {
 
 			for {
 				p.advance()
-				values.Elements = append(values.Elements, p.parseExpr(lowest))
+				values.Elements = append(values.Elements, p.parseCaseValue())
 				if p.atPeek(token.Comma) {
 					p.advance()
 					continue
@@ -1467,6 +1485,14 @@ func (p *Parser) parseSwitch() ast.Node {
 				break
 			}
 			c.Values = values
+
+			// A `when` clause guards the arm: it is tested only once one of the
+			// values has already matched.
+			if p.atPeek(token.When) {
+				p.advance()
+				p.advance()
+				c.Guard = p.parseExpr(lowest)
+			}
 
 			p.advance()
 			if p.at(token.Then) {

--- a/internal/resolver/corpus_test.go
+++ b/internal/resolver/corpus_test.go
@@ -114,6 +114,7 @@ var expectedResolveErrors = map[string]string{
 	"as-unknown-type.ari":            "converts to a name that is not a type",
 	"unknown-parameter-type.ari":     "annotates with names that are not types",
 	"default-type-violation.ari":     "gives a parameter a default its annotation forbids",
+	"switch-unknown-type-case.ari":   "matches against a name that is not a type",
 }
 
 // Three cases that USED to fail now resolve cleanly, which is the point:

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -469,16 +469,15 @@ func (r *Resolver) node(n ast.Node) {
 	case *ast.Switch:
 		r.node(n.Control)
 		for _, c := range n.Cases {
-			// A case value may be `_`, the wildcard. Walk the elements rather
-			// than the list so the placeholder is not reported as one out of
-			// position.
+			// A case value may be `_`, the wildcard, and an array pattern may
+			// hold them too. Walk the elements rather than the list so a
+			// placeholder is not reported as one out of position.
 			if c.Values != nil {
 				for _, el := range c.Values.Elements {
-					if _, wild := el.(*ast.Placeholder); !wild {
-						r.node(el)
-					}
+					r.caseValue(el)
 				}
 			}
+			r.node(c.Guard)
 			r.node(c.Body)
 		}
 		if n.Default != nil {
@@ -543,6 +542,24 @@ func (r *Resolver) node(n ast.Node) {
 		*ast.Integer, *ast.Float, *ast.String, *ast.Atom,
 		*ast.Boolean, *ast.Nil:
 		// Nothing to resolve.
+	}
+}
+
+// caseValue resolves one value of a case arm, where `_` is a wildcard rather
+// than a name and `is Type` names a type rather than a value.
+func (r *Resolver) caseValue(el ast.Node) {
+	switch el := el.(type) {
+	case *ast.Placeholder:
+	case *ast.TypeCase:
+		r.typeName(el.Name)
+	case *ast.Array:
+		if el.List != nil {
+			for _, item := range el.List.Elements {
+				r.caseValue(item)
+			}
+		}
+	default:
+		r.node(el)
 	}
 }
 

--- a/internal/token/token.go
+++ b/internal/token/token.go
@@ -102,6 +102,7 @@ const (
 	Then
 	Switch
 	Case
+	When
 	Default
 	Break
 	Continue
@@ -190,6 +191,7 @@ var names = [...]string{
 	Then:     "then",
 	Switch:   "switch",
 	Case:     "case",
+	When:     "when",
 	Default:  "default",
 	Break:    "break",
 	Continue: "continue",
@@ -227,6 +229,7 @@ var keywords = map[string]Kind{
 	"then":     Then,
 	"switch":   Switch,
 	"case":     Case,
+	"when":     When,
 	"default":  Default,
 	"break":    Break,
 	"continue": Continue,

--- a/testdata/semantics/control/switch-guard.ari
+++ b/testdata/semantics/control/switch-guard.ari
@@ -1,0 +1,34 @@
+// A `when` clause is tested only once one of the arm's values has matched, so
+// the control-less form can replace an else-if chain without repeating the
+// subject.
+let describe = func (n) do
+  switch n
+  case 1..9 when n % 2 == 0 then "even digit"
+  case 1..9 then "odd digit"
+  default then "not a digit"
+  end
+end
+println(describe(4))
+println(describe(5))
+println(describe(50))
+
+// A guard that fails falls through to the next arm rather than to default.
+println(switch 5 do
+  case 5 when false then "guarded out"
+  case 5 then "plain"
+  default then "other"
+end)
+
+// It works on alternatives too, and on the control-less form.
+let sign = func (n) do
+  switch
+  case n < 0 then "negative"
+  case n > 0 when n > 100 then "big"
+  case n > 0 then "positive"
+  default then "zero"
+  end
+end
+println(sign(-1))
+println(sign(500))
+println(sign(5))
+println(sign(0))

--- a/testdata/semantics/control/switch-guard.out
+++ b/testdata/semantics/control/switch-guard.out
@@ -1,0 +1,9 @@
+even digit
+odd digit
+not a digit
+plain
+negative
+big
+positive
+zero
+--- exit: 0

--- a/testdata/semantics/control/switch-pattern-array.ari
+++ b/testdata/semantics/control/switch-pattern-array.ari
@@ -1,8 +1,38 @@
+// A comma-separated case list is always a list of ALTERNATIVES. It used to mean
+// that for a scalar control and "the array [1, 2]" for an array control, chosen
+// by the runtime type of the subject — one syntax with two meanings.
+//
+// A pattern is written as an array literal, which is a spelling the parser can
+// already tell apart.
 println(switch [1, 2] do
-  case 1, 2 then "one two"
+  case 1, 2 then "alternatives"
+  case [1, 2] then "pattern"
+  default then "other"
+end)
+println(switch 2 do
+  case 1, 2 then "one or two"
+  default then "other"
+end)
+
+// `_` inside a pattern is a wildcard for that element.
+println(switch [1, 9] do
+  case [1, _] then "one anything"
   default then "other"
 end)
 println(switch [1, 9] do
-  case 1, _ then "one anything"
+  case [2, _] then "two anything"
+  default then "other"
+end)
+
+// A pattern of a different arity is simply a different array.
+println(switch [1, 9] do
+  case [1] then "just one"
+  default then "other"
+end)
+
+// A bare `_` among alternatives is still the match-anything wildcard, which is
+// `default` said in an arm.
+println(switch [1, 9] do
+  case 2, _ then "anything"
   default then "other"
 end)

--- a/testdata/semantics/control/switch-pattern-array.out
+++ b/testdata/semantics/control/switch-pattern-array.out
@@ -1,3 +1,7 @@
-one two
+pattern
+one or two
 one anything
+other
+other
+anything
 --- exit: 0

--- a/testdata/semantics/control/switch-range-case.ari
+++ b/testdata/semantics/control/switch-range-case.ari
@@ -1,0 +1,26 @@
+// A range in case position tests membership rather than equality. An Int range
+// is tested by comparison, so `case 1..1000000` costs nothing.
+let size = func (n) do
+  switch n
+  case 1..9 then "digit"
+  case 10..99 then "two digits"
+  case 100..1000000 then "big"
+  default then "out of range"
+  end
+end
+println(size(5))
+println(size(42))
+println(size(5000))
+println(size(0))
+
+// A descending range covers the same span.
+println(switch 5 do
+  case 9..1 then "in range"
+  default then "out"
+end)
+
+// A character range materialises, which is what `..` does outside a case.
+println(switch "d" do
+  case "a".."f" then "hex letter"
+  default then "other"
+end)

--- a/testdata/semantics/control/switch-range-case.out
+++ b/testdata/semantics/control/switch-range-case.out
@@ -1,0 +1,7 @@
+digit
+two digits
+big
+out of range
+in range
+hex letter
+--- exit: 0

--- a/testdata/semantics/control/switch-type-case.ari
+++ b/testdata/semantics/control/switch-type-case.ari
@@ -1,0 +1,19 @@
+// `is` in case position matches on the control's type. Aria already had `is` as
+// an operator; this is it where there is no left-hand side to write, which was
+// the most common reason to reach for a chain of typeof comparisons.
+let classify = func (v) do
+  switch v
+  case is Int when v > 100 then "large int"
+  case is Int then "int"
+  case is String then "string"
+  case is Array then "array"
+  case is Nil then "nothing"
+  case is Any then "something else"
+  end
+end
+println(classify(500))
+println(classify(5))
+println(classify("x"))
+println(classify([1]))
+println(classify(nil))
+println(classify(1.5))

--- a/testdata/semantics/control/switch-type-case.out
+++ b/testdata/semantics/control/switch-type-case.out
@@ -1,0 +1,7 @@
+large int
+int
+string
+array
+nothing
+something else
+--- exit: 0

--- a/testdata/semantics/errors/switch-unknown-type-case.ari
+++ b/testdata/semantics/errors/switch-unknown-type-case.ari
@@ -1,0 +1,5 @@
+// A type case naming something that is not a type would silently never match.
+println(switch 1 do
+  case is Banana then "never"
+  default then "always"
+end)

--- a/testdata/semantics/errors/switch-unknown-type-case.out
+++ b/testdata/semantics/errors/switch-unknown-type-case.out
@@ -1,0 +1,4 @@
+switch-unknown-type-case.ari:3:11: error: 'Banana' is not a type: expected one of Nil, Bool, Int, Float, String, Atom, Array, Dictionary, Function, Module, Any
+    case is Banana then "never"
+            ^^^^^^
+--- exit: 1


### PR DESCRIPTION
`switch` is the language's stated answer to the missing `else if` — the README says so — and it needed three things to carry that weight, plus one ambiguity settling first.

## The ambiguity

`case 1, 2` meant "1 or 2" for a scalar control and "the array `[1, 2]`" for an array control, chosen by the runtime type of the subject. One syntax, two meanings, both documented in the README as features.

**A comma-separated list is always alternatives.** A pattern is written as an array literal, `case [1, _]`, which the parser can already tell apart; `_` inside one is a wildcard for that element, and a pattern of a different arity is simply a different array. A bare `_` among alternatives is still the match-anything wildcard.

That also settles what a case arm's values *are*, which #14 needs before capture can be added to them.

## The three additions

- **`when` guards**, tested only once one of the arm's values has matched, so the control-less form replaces an else-if chain without repeating the subject. A guard that fails falls through to the next arm, not to `default`.
- **`case is Type`** — `is` where there is no left-hand side to write. The type name goes through the same resolve-time check as `is` and `as`, so a typo is a diagnostic rather than an arm that never matches.
- **`case a..b`** tests membership. An `Int` range is tested by comparison, so `case 1..1000000` costs nothing; anything else materialises, as `..` does outside a case.

## Cases

`control/switch-guard`, `control/switch-type-case`, `control/switch-range-case` and `errors/switch-unknown-type-case` added. `control/switch-pattern-array` re-recorded deliberately — it is the case that pinned the ambiguity. The README's Pattern Matching section is rewritten to the one meaning; the ruling is in `docs/architecture.md`.

Closes #20