### PR TITLE
Recoverable errors, in the two shapes that fit the language

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ go test ./internal/parser/  -run=Fuzz -fuzz=FuzzParse -fuzztime=30s
 
 ## The characterization suite is the arbiter
 
-`testdata/semantics/` holds 198 `.ari` files, each with a `.out` golden recording exactly
+`testdata/semantics/` holds 203 `.ari` files, each with a `.out` golden recording exactly
 what the interpreter prints and what it exits with.
 
 **If a golden changes, you changed the language.** That is either the point of your change

--- a/README.md
+++ b/README.md
@@ -1375,6 +1375,51 @@ Nothing ground breaking in here. You can write either single line or multi line 
 */
 ```
 
+## Errors
+
+A failure halts the program and exits non-zero. That's the right rule for a genuine fault, and the wrong one for "this key isn't in this dictionary" — so Aria has two shapes for recovering, which answer different questions.
+
+### Tagged results
+
+A fallible operation answers `[:ok, value]` or `[:error, reason]`. That needs no special syntax, since `switch` with array patterns and `let` capture takes one apart:
+
+```swift
+let user = [:name => "Ada"]
+println(switch Dict.insert(user, :name, "Bob")
+case [:ok, let updated] then updated
+case [:error, let why] then "could not: #{why}"
+end)
+```
+
+The `Result` module gives the shape a name and the usual ways to consume it — `Result.ok?`, `Result.unwrap` with a fallback, `Result.expect`, `Result.reason`:
+
+```swift
+let user = [:name => "Ada"]
+println(Result.unwrap(Dict.delete(user, :missing), user))
+```
+
+### try and rescue
+
+`try` catches a failure and is an expression, like everything else — it evaluates to whichever block ran. The rescued value is a dictionary with `:message`, `:file`, `:line` and `:column`:
+
+```swift
+println(try
+  1 / 0
+rescue e
+  "caught: #{e.message}"
+end)
+```
+
+Every runtime error is catchable, including one the runtime raised itself: whether a division by zero is a bug or a validation outcome is the caller's call, not the language's. The name after `rescue` is optional. A `return` inside a `try` is not a failure and unwinds to its function as usual.
+
+`Result.attempt` bridges the two shapes:
+
+```swift
+println(Result.attempt(() -> 1 / 0))
+```
+
+The library draws the line at data versus misuse. `Dict.insert`, `Dict.update` and `Dict.delete` answer tagged results, because a key that is or isn't there is an ordinary outcome. Passing the wrong kind of thing — `Math.max("a", 1)` — still raises, because that's a mistake in the caller.
+
 ## Standard Library
 
 The Standard Library is fully written in Aria with the help of a few essential functions provided by the runtime. That is currently the best source to check out some "production" Aria code and see what it's capable of. [Read the documentation](https://github.com/fadion/aria/wiki/Standard-Library).
@@ -1419,6 +1464,8 @@ Enum.sortBy(["bbb", "a", "cc"], (s) -> String.count(s)) // ["a", "cc", "bbb"]
 let user = [:name => "Ada"]
 println(Dict.get(user, :city, "unknown"))
 ```
+
+**`Result`** — `ok`, `error`, `ok?`, `error?`, `unwrap`, `expect`, `reason`, `attempt`. See [Errors](#errors).
 
 **`Type`** covers type inspection and conversion.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -637,6 +637,47 @@ main.ari:3:11: error: unterminated string
 A failed run exits non-zero. The original exited `0` on every parse and runtime error
 alike, which made failure undetectable from a script.
 
+### Aria has recoverable errors, in two shapes
+
+It used to have none, and that answer was not written down anywhere, which made it read as
+an oversight rather than a position. `panic` was terminal, every runtime fault unwound to
+the top of `Run`, and no Aria code could be defensive.
+
+The two shapes answer different questions, and the pairing is the usual one.
+
+**A tagged-result convention, for outcomes a caller should expect.** A fallible operation
+answers `[:ok, value]` or `[:error, reason]`. This needs no new syntax — `switch` with array
+patterns and `let` capture takes one apart — and the `Result` module gives the shape a name
+along with the common ways to consume it: `ok?`, `unwrap` with a fallback, `expect`,
+`reason`.
+
+**`try ... rescue e ... end`, for genuine faults.** An expression, like everything else in
+Aria: it evaluates to whichever block ran.
+
+Every runtime error is catchable, including one the runtime raised itself. The line between
+"a fault" and "an expected failure" is the *caller's* to draw, not the runtime's — the same
+division by zero is a bug in one program and a validation outcome in another. What is not
+catchable is anything that is not a runtime error: a parse or resolve failure means the
+program never started. A control signal is not a failure either, so a `return` inside a
+`try` unwinds to its function as it would anywhere else.
+
+The rescued value is a dictionary — `:message`, `:file`, `:line`, `:column` — rather than a
+string. The message is what a program usually wants, but where it happened is what lets a
+rescue report anything useful, and a dictionary is what dotted access already reads well on.
+
+`Result.attempt(fn)` is the bridge: it runs a function and turns whatever it raises into an
+error result.
+
+**Where the library draws the line.** `Dict.insert`, `Dict.update` and `Dict.delete` answer
+tagged results: a key that is already there, or one that is not, is an ordinary outcome, and
+the only way to avoid the old panic was to duplicate the check before every call. Passing
+the wrong *kind* of thing — `Math.max("a", 1)` — still raises, because that is a mistake in
+the caller rather than an outcome, and `try` is what catches it. Data versus misuse is the
+line.
+
+A failure nobody catches still halts the program and exits non-zero. `try` is what makes
+recovery possible, not what makes failure quiet.
+
 ### A runtime error carries the file its span indexes into
 
 A `source.Span` is a pair of byte offsets and nothing else, so it only means something
@@ -663,7 +704,7 @@ something the author of an Aria program can act on.
 
 ## The characterization suite
 
-`testdata/semantics/` holds 198 cases. Each `.ari` file has a `.out` golden recording
+`testdata/semantics/` holds 203 cases. Each `.ari` file has a `.out` golden recording
 exactly what the interpreter prints and what it exits with.
 
 ```bash

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -506,6 +506,26 @@ type Continue struct{ Base }
 
 func (n *Continue) Inspect() string { return "continue" }
 
+// Try runs Body and, if a runtime error unwinds out of it, runs Rescue instead
+// with Name bound to the error.
+//
+// An expression, like everything else in Aria: it evaluates to whichever block
+// ran. Name is optional, for a rescue that does not care why.
+type Try struct {
+	Base
+	Body   *Block
+	Name   *Identifier
+	Rescue *Block
+}
+
+func (n *Try) Inspect() string {
+	out := "try " + inspectOr(n.Body, "") + " rescue"
+	if n.Name != nil {
+		out += " " + n.Name.Inspect()
+	}
+	return out + " " + inspectOr(n.Rescue, "") + " end"
+}
+
 // While repeats a body while its condition holds. Until is the same node with
 // the condition negated, so the two share every rule.
 //

--- a/internal/ast/walk.go
+++ b/internal/ast/walk.go
@@ -135,6 +135,10 @@ func Children(n Node) []Node {
 		}
 		node(n.Enumerable)
 		block(n.Body)
+	case *Try:
+		block(n.Body)
+		ident(n.Name)
+		block(n.Rescue)
 	case *While:
 		node(n.Condition)
 		block(n.Body)

--- a/internal/interp/interp.go
+++ b/internal/interp/interp.go
@@ -348,6 +348,8 @@ func (i *Interp) eval(n ast.Node, e *env) value.Value {
 		return i.evalFor(n, e)
 	case *ast.While:
 		return i.evalWhile(n, e)
+	case *ast.Try:
+		return i.evalTry(n, e)
 
 	case *ast.Function:
 		return &Function{Decl: n, Env: e, File: i.curFile()}
@@ -1606,4 +1608,83 @@ func (i *Interp) destructure(pattern *ast.ArrayPattern, v value.Value, e *env, s
 			e.define(el.Name.Value, value.NewArray(append([]value.Value{}, arr.Elems()[idx:arr.Len()-after]...)))
 		}
 	}
+}
+
+// evalTry runs a body and, if a runtime error unwinds out of it, runs the
+// rescue instead.
+//
+// Every runtime error is catchable, including one the runtime raised itself. The
+// line between "a fault" and "an expected failure" is the caller's to draw, not
+// the runtime's: the same division by zero is a bug in one program and a
+// validation outcome in another. What is not catchable is anything that is not a
+// runtime error — a parse or resolve failure means the program never started.
+//
+// Control signals pass straight through. A `return` inside the body is not a
+// failure, so it unwinds to its function as it would anywhere else.
+func (i *Interp) evalTry(n *ast.Try, e *env) value.Value {
+	depth := len(i.frames)
+
+	result, caught := i.attempt(n.Body, e)
+	if caught == nil {
+		return result
+	}
+
+	// Unwinding ran every deferred frame pop on the way out, but truncating is
+	// what makes that a guarantee rather than an assumption.
+	if len(i.frames) > depth {
+		i.frames = i.frames[:depth]
+	}
+	// The failure aborted whatever control transfer was in flight.
+	i.signal, i.breaking, i.retval = sigNone, 0, nil
+
+	scope := newEnv(e)
+	if n.Name != nil {
+		scope.define(n.Name.Value, i.errorValue(caught))
+	}
+	return i.evalBlock(n.Rescue, scope)
+}
+
+// attempt evaluates a block, returning the error that unwound out of it rather
+// than letting it reach the top.
+func (i *Interp) attempt(b *ast.Block, e *env) (result value.Value, caught *Error) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			return
+		}
+		re, ok := r.(*Error)
+		if !ok {
+			// Not ours: a Go bug, and swallowing it would hide one.
+			panic(r)
+		}
+		result, caught = value.NilValue, re
+	}()
+
+	return i.evalBlock(b, newEnv(e)), nil
+}
+
+// errorValue renders a runtime error as an ordinary Aria value.
+//
+// A dictionary rather than a string: the message is what a program usually
+// wants, but where it happened is what makes a rescue able to report anything
+// useful, and a dictionary is what dotted access already reads well on —
+// `e.message`, `e.line`.
+func (i *Interp) errorValue(err *Error) value.Value {
+	file := err.File
+	if file == nil {
+		file = i.file
+	}
+
+	name, line, col := "", 0, 0
+	if file != nil {
+		pos := file.Position(err.Span.Start)
+		name, line, col = file.Name, pos.Line, pos.Col
+	}
+
+	return value.NewDict([]value.Pair{
+		{Key: value.Atom("message"), Value: value.String(err.Msg)},
+		{Key: value.Atom("file"), Value: value.String(name)},
+		{Key: value.Atom("line"), Value: value.Int(line)},
+		{Key: value.Atom("column"), Value: value.Int(col)},
+	})
 }

--- a/internal/interp/interp_test.go
+++ b/internal/interp/interp_test.go
@@ -840,8 +840,8 @@ func TestStdlibDict(t *testing.T) {
 		{`println(Dict.size([:a => 1]))`, "1"},
 		{`println(Dict.contains?([:a => 1], :a))`, "true"},
 		{`println(Dict.empty?([=>]))`, "true"},
-		{`println(Dict.insert([:a => 1], :b, 2))`, "[:a => 1, :b => 2]"},
-		{`println(Dict.update([:a => 1], :a, 9))`, "[:a => 9]"},
+		{`println(Dict.insert([:a => 1], :b, 2))`, "[:ok, [:a => 1, :b => 2]]"},
+		{`println(Dict.update([:a => 1], :a, 9))`, "[:ok, [:a => 9]]"},
 	}
 	for _, test := range tests {
 		if got := withStdlib(t, test.src); got != test.want {
@@ -853,7 +853,7 @@ func TestStdlibDict(t *testing.T) {
 // Dict.insert must not modify its argument either.
 func TestStdlibDictInsertDoesNotMutate(t *testing.T) {
 	const src = `let d = [:a => 1]
-let e = Dict.insert(d, :b, 2)
+let e = Result.expect(Dict.insert(d, :b, 2))
 println(d)
 println(e)`
 	got := withStdlib(t, src)
@@ -928,7 +928,7 @@ f(0)`, "call depth")
 // <stdlib>, so rendering it against the user's file pointed at nothing.
 func TestRuntimeErrorCarriesItsOwnFile(t *testing.T) {
 	var out, errOut strings.Builder
-	_, err := interp.Eval("test.ari", `println(Dict.delete([:a => 1], :zz))`, interp.Options{
+	_, err := interp.Eval("test.ari", `println(Math.max("a", 1))`, interp.Options{
 		Out: &out, Err: &errOut, In: strings.NewReader(""),
 	})
 	if err == nil {
@@ -1307,7 +1307,7 @@ func TestStdlibDictCoverage(t *testing.T) {
 		{`println(Dict.has?([:a => 1], "a"))`, "true"},
 		{`println(Dict.has?([:a => 1], :zz))`, "false"},
 		{`println(Dict.has?([:a => nil], :a))`, "true"},
-		{`println(Dict.delete([:a => nil], :a))`, "[=>]"},
+		{`println(Dict.delete([:a => nil], :a))`, "[:ok, [=>]]"},
 		{`println(Dict.map([:a => 1], (k, v) -> v * 10))`, "[:a => 10]"},
 		{`println(Dict.filter([:a => 1, :b => 2], (k, v) -> v > 1))`, "[:b => 2]"},
 		{`println(Dict.toPairs([:a => 1]))`, "[[:a, 1]]"},
@@ -1911,4 +1911,102 @@ func TestSwitchCapture(t *testing.T) {
 
 	// A capture lives in its own arm and nowhere else.
 	fails(t, "switch 1 do\n  case let n then n\nend\nprintln(n)", "'n' is not defined")
+}
+
+// There was no way to recover from anything: panic was terminal and every
+// runtime fault unwound to the top of Run.
+func TestTryRescue(t *testing.T) {
+	tests := []struct{ src, want string }{
+		{`try 1 / 0 rescue e e.message end`, "division by zero"},
+		{`try 42 rescue e "never" end`, "42"},
+		{`try panic("boom") rescue e e.message end`, "boom"},
+		// Every runtime error is catchable, the runtime's own included.
+		{`try 5 + "x" rescue e e.message end`, `cannot apply '+' to Int and String`},
+		{"var a = [1]\ntry a[9] = 2 rescue e e.message end", "index 9 is out of bounds for length 1"},
+		// The name is optional.
+		{`try 1 / 0 rescue "went wrong" end`, "went wrong"},
+		// It nests, and a rescue may raise in turn.
+		{`try
+  try 1 / 0 rescue e panic("again: " + e.message) end
+rescue e
+  e.message
+end`, "again: division by zero"},
+	}
+	for _, test := range tests {
+		if got := str(t, test.src); got != test.want {
+			t.Errorf("%s: got %s, want %s", test.src, got, test.want)
+		}
+	}
+
+	// The error is a dictionary, so a rescue can report where as well as what.
+	if got := output(t, `try
+  1 / 0
+rescue e
+  println(e.message)
+  println(e.line)
+end`); got != "division by zero\n2\n" {
+		t.Errorf("got %q", got)
+	}
+
+	// A control signal is not a failure.
+	if got := output(t, `let f = func () do
+  try
+    return "through"
+  rescue e
+    "rescued"
+  end
+end
+println(f())`); got != "through\n" {
+		t.Errorf("got %q", got)
+	}
+
+	// The rescued name lives in the rescue block and nowhere else.
+	fails(t, "try 1 / 0 rescue e e end\nprintln(e)", "'e' is not defined")
+
+	// A failure nobody catches still halts.
+	fails(t, `println(1 / 0)`, "division by zero")
+}
+
+// The frame stack has to come back to where it was, or a caught failure would
+// leave the interpreter counting from the wrong place.
+func TestTryRestoresCallDepth(t *testing.T) {
+	if got := output(t, `let f = func (n) do f(n + 1) end
+println(try f(0) rescue "caught" end)
+let g = func (n) do
+  if n == 0 then return 0 end
+  g(n - 1)
+end
+println(g(100))
+println(try f(0) rescue "caught again" end)`); got != "caught\n0\ncaught again\n" {
+		t.Errorf("got %q", got)
+	}
+}
+
+// The tagged-result convention, and the library's line between data and misuse.
+func TestResultConvention(t *testing.T) {
+	tests := []struct{ src, want string }{
+		{`println(Result.ok(1))`, "[:ok, 1]"},
+		{`println(Result.ok?(Result.ok(1)))`, "true"},
+		{`println(Result.ok?([1, 2]))`, "false"},
+		{`println(Result.unwrap(Result.error("x"), 0))`, "0"},
+		{`println(Result.expect(Result.ok(9)))`, "9"},
+		{`println(Result.reason(Result.error("bad")))`, "bad"},
+		{`println(Result.attempt(() -> 1 / 0))`, `[:error, "division by zero"]`},
+		{`println(Result.attempt(() -> 42))`, "[:ok, 42]"},
+
+		// A key that is or is not there is an outcome, not a fault.
+		{`println(Dict.insert([:a => 1], :b, 2))`, "[:ok, [:a => 1, :b => 2]]"},
+		{`println(Dict.insert([:a => 1], :a, 2))`, `[:error, "Dictionary key 'a' already exists"]`},
+		{`println(Dict.delete([:a => 1], :zz))`, `[:error, "Dictionary key 'zz' doesn't exist"]`},
+	}
+	for _, test := range tests {
+		if got := withStdlib(t, test.src); got != test.want {
+			t.Errorf("%s: got %q, want %q", test.src, got, test.want)
+		}
+	}
+
+	// Passing the wrong kind of thing still raises.
+	if got := withStdlib(t, `println(try Math.max("a", 1) rescue e e.message end)`); got != "Math.max() expects a Float or Int" {
+		t.Errorf("got %q", got)
+	}
 }

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -282,7 +282,7 @@ func (p *Parser) recover() {
 func startsConstruct(kind token.Kind) bool {
 	switch kind {
 	case token.Let, token.Var, token.Func, token.If, token.Switch, token.For,
-		token.While, token.Until,
+		token.While, token.Until, token.Try,
 		token.Module, token.Import, token.Return, token.Break, token.Continue,
 		token.Case, token.Default, token.End:
 		return true
@@ -400,6 +400,8 @@ func (p *Parser) parsePrefix() ast.Node {
 		return p.parseIf()
 	case token.Switch:
 		return p.parseSwitch()
+	case token.Try:
+		return p.parseTry()
 	case token.While:
 		return p.parseWhile(false)
 	case token.Until:
@@ -1290,6 +1292,37 @@ func (p *Parser) parseBreak() ast.Node {
 		n.Sp = span(n.Sp, p.tok.Span)
 	}
 	return n
+}
+
+// parseTry reads `try [do] body rescue [name] body end`.
+func (p *Parser) parseTry() ast.Node {
+	start := p.tok.Span
+	node := &ast.Try{Base: ast.Base{Sp: start}}
+
+	p.advance()
+	if p.at(token.Do) {
+		p.advance()
+	}
+
+	node.Body = p.parseBlock(token.Rescue, token.End)
+	if !p.at(token.Rescue) {
+		return p.bad(span(start, p.tok.Span), "missing 'rescue' in 'try'")
+	}
+
+	// The name is optional, for a rescue that does not care why.
+	if p.atPeek(token.Ident) {
+		p.advance()
+		node.Name = &ast.Identifier{Base: ast.Base{Sp: p.tok.Span}, Value: p.text(p.tok)}
+	}
+
+	p.advance()
+	node.Rescue = p.parseBlock(token.End)
+	if !p.at(token.End) {
+		return p.bad(span(start, p.tok.Span), "missing 'end' to close 'try'")
+	}
+
+	node.Sp = span(start, p.tok.Span)
+	return node
 }
 
 // parseWhile reads `while cond [do] body end`, or the same with `until`, which

--- a/internal/resolver/corpus_test.go
+++ b/internal/resolver/corpus_test.go
@@ -116,6 +116,7 @@ var expectedResolveErrors = map[string]string{
 	"default-type-violation.ari":     "gives a parameter a default its annotation forbids",
 	"switch-unknown-type-case.ari":   "matches against a name that is not a type",
 	"switch-capture-scope.ari":       "reads a capture outside its own arm",
+	"try-rescue-scope.ari":           "reads a rescued name outside its rescue",
 }
 
 // Three cases that USED to fail now resolve cleanly, which is the point:

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -504,6 +504,22 @@ func (r *Resolver) node(n ast.Node) {
 
 	case *ast.For:
 		r.forLoop(n)
+	case *ast.Try:
+		r.node(n.Body)
+		// The rescue's name is bound for the rescue block and nowhere else, so
+		// it gets a scope of its own — the block's own Block would push a
+		// second one, so its contents are resolved directly.
+		r.push()
+		if n.Name != nil {
+			r.declare(n.Name, KindLet, false)
+		}
+		if n.Rescue != nil {
+			for _, node := range n.Rescue.Nodes {
+				r.node(node)
+			}
+		}
+		r.pop(n)
+
 	case *ast.While:
 		r.node(n.Condition)
 		r.loops++

--- a/internal/stdlib/dict.ari
+++ b/internal/stdlib/dict.ari
@@ -19,26 +19,35 @@ module Dict
     size(dict) == 0
   end
 
-  let insert = func (dict: Dictionary, key, value) -> Dictionary
-    // The index, not `dict[key] != nil`: a key whose value is nil exists.
+  // insert, update and delete answer a tagged result rather than raising.
+  //
+  // A key that is already there, or one that is not, is an ordinary outcome a
+  // caller should be able to handle — and the only way to avoid the old panic
+  // was to duplicate the check before every call. A caller who knows the key's
+  // state can still say so with Result.expect, and one who has a default can
+  // use Result.unwrap. See docs/architecture.md.
+  //
+  // The check goes through the index, not `dict[key] != nil`: a key whose value
+  // is nil exists.
+  let insert = func (dict: Dictionary, key, value) -> Array
     if has?(dict, key)
-      panic("Dictionary key '" + String(key) + "' already exists")
+      return Result.error("Dictionary key '" + String(key) + "' already exists")
     end
 
-    dict + [key => value]
+    Result.ok(dict + [key => value])
   end
 
-  let update = func (dict: Dictionary, key, value) -> Dictionary
+  let update = func (dict: Dictionary, key, value) -> Array
     if !has?(dict, key)
-      panic("Dictionary key '" + String(key) + "' doesn't exist")
+      return Result.error("Dictionary key '" + String(key) + "' doesn't exist")
     end
 
-    dict + [key => value]
+    Result.ok(dict + [key => value])
   end
 
-  let delete = func (dict: Dictionary, key) -> Dictionary
+  let delete = func (dict: Dictionary, key) -> Array
     if !has?(dict, key)
-      panic("Dictionary key '" + String(key) + "' doesn't exist")
+      return Result.error("Dictionary key '" + String(key) + "' doesn't exist")
     end
 
     var purged = [=>]
@@ -47,7 +56,7 @@ module Dict
         purged[k] = v
       end
     end
-    purged
+    Result.ok(purged)
   end
 
   let keys = func (dict: Dictionary) -> Array

--- a/internal/stdlib/result.ari
+++ b/internal/stdlib/result.ari
@@ -1,0 +1,69 @@
+// Result is the tagged-result convention, written down.
+//
+// A fallible operation answers [:ok, value] or [:error, reason], which needs no
+// new syntax: `switch` with array patterns and `let` capture takes one apart.
+// These are here so the shape has a name and the common ways of consuming one
+// do not have to be rewritten at every call site.
+//
+// The convention is for outcomes a caller should expect — a key that is not
+// there, a file that does not exist. A genuine fault still raises, and `try` is
+// what catches that. See docs/architecture.md.
+module Result
+
+  let ok = func (value) -> Array
+    [:ok, value]
+  end
+
+  let error = func (reason) -> Array
+    [:error, reason]
+  end
+
+  let ok? = func (result) -> Bool
+    result is Array && Enum.size(result) == 2 && result[0] == :ok
+  end
+
+  let error? = func (result) -> Bool
+    result is Array && Enum.size(result) == 2 && result[0] == :error
+  end
+
+  // unwrap answers the value, or the fallback when the result is an error, so a
+  // caller who has a sensible default does not have to switch on the shape.
+  let unwrap = func (result, fallback = nil)
+    if Result.ok?(result)
+      return result[1]
+    end
+    fallback
+  end
+
+  // expect answers the value, or raises with the reason. It is the deliberate
+  // way to say "this cannot fail here", which is otherwise written by ignoring
+  // the tag and reading result[1] anyway.
+  let expect = func (result)
+    if Result.ok?(result)
+      return result[1]
+    end
+    if Result.error?(result)
+      panic(String(result[1]))
+    end
+    panic("Result.expect() expects an [:ok, value] or [:error, reason] pair")
+  end
+
+  // reason answers what went wrong, or nil for an ok result.
+  let reason = func (result)
+    if Result.error?(result)
+      return result[1]
+    end
+    nil
+  end
+
+  // attempt is the bridge between the two shapes: it runs fn and turns whatever
+  // it raises into an error result.
+  let attempt = func (fn: Function) -> Array
+    try
+      [:ok, fn()]
+    rescue e
+      [:error, e.message]
+    end
+  end
+
+end

--- a/internal/token/token.go
+++ b/internal/token/token.go
@@ -106,6 +106,8 @@ const (
 	Default
 	Break
 	Continue
+	Try
+	Rescue
 	Module
 	Import
 )
@@ -195,6 +197,8 @@ var names = [...]string{
 	Default:  "default",
 	Break:    "break",
 	Continue: "continue",
+	Try:      "try",
+	Rescue:   "rescue",
 	Module:   "module",
 	Import:   "import",
 }
@@ -233,6 +237,8 @@ var keywords = map[string]Kind{
 	"default":  Default,
 	"break":    Break,
 	"continue": Continue,
+	"try":      Try,
+	"rescue":   Rescue,
 	"module":   Module,
 	"import":   Import,
 	// true, false and nil are keywords lexically, but carry a literal's kind

--- a/testdata/semantics/errors/stdlib-runtime-error.ari
+++ b/testdata/semantics/errors/stdlib-runtime-error.ari
@@ -1,4 +1,8 @@
 // Every panic() in the standard library raises against a span in <stdlib>.
 // Rendered against this file the offset usually lands past the end of it, so
 // the reader got a line number that does not exist and no caret at all.
-println(Dict.delete([:a => 1], :zz))
+//
+// Dict.delete used to be the trigger here; it answers a tagged result now, so
+// this uses one of the panics that stayed — passing the wrong kind of thing is
+// a mistake in the caller, not an outcome. See docs/architecture.md.
+println(Math.max("a", 1))

--- a/testdata/semantics/errors/stdlib-runtime-error.out
+++ b/testdata/semantics/errors/stdlib-runtime-error.out
@@ -1,4 +1,4 @@
-<stdlib>/dict.ari:41:7: error: Dictionary key 'zz' doesn't exist
-        panic("Dictionary key '" + String(key) + "' doesn't exist")
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+<stdlib>/math.ari:64:9: error: Math.max() expects a Float or Int
+          panic("Math.max() expects a Float or Int")
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 --- exit: 1

--- a/testdata/semantics/errors/try-rescue-scope.ari
+++ b/testdata/semantics/errors/try-rescue-scope.ari
@@ -1,0 +1,7 @@
+// The rescued name is bound for the rescue block and nowhere else.
+try
+  1 / 0
+rescue e
+  println(e.message)
+end
+println(e)

--- a/testdata/semantics/errors/try-rescue-scope.out
+++ b/testdata/semantics/errors/try-rescue-scope.out
@@ -1,0 +1,4 @@
+try-rescue-scope.ari:7:9: error: 'e' is not defined
+  println(e)
+          ^
+--- exit: 1

--- a/testdata/semantics/errors/try-rescue.ari
+++ b/testdata/semantics/errors/try-rescue.ari
@@ -1,0 +1,67 @@
+// There was no way to recover from anything: panic was terminal, every runtime
+// fault unwound to the top of Run, and no Aria code could be defensive.
+//
+// `try` is an expression, like everything else. It evaluates to whichever block
+// ran.
+println(try
+  1 / 0
+rescue e
+  "caught: #{e.message}"
+end)
+
+println(try
+  42
+rescue e
+  "never"
+end)
+
+// Every runtime error is catchable, including one the runtime raised itself:
+// the line between a fault and an expected failure is the caller's to draw.
+println(try panic("boom") rescue e e.message end)
+var a = [1, 2, 3]
+println(try a[10] = "x" rescue e e.message end)
+println(try 5 + "x" rescue e e.message end)
+
+// The name is optional, for a rescue that does not care why.
+println(try 1 / 0 rescue "something went wrong" end)
+
+// The error is a dictionary, so a rescue can report where as well as what.
+println(try
+  Math.max("a", 1)
+rescue e
+  "#{e.file}:#{e.line} #{e.message}"
+end)
+
+// It nests, and a rescue may raise in turn.
+println(try
+  try
+    1 / 0
+  rescue e
+    panic("rethrown: #{e.message}")
+  end
+rescue e
+  e.message
+end)
+
+// A control signal is not a failure: a return inside a try unwinds to its
+// function, as it would anywhere else.
+let f = func () do
+  try
+    return "returned through the try"
+  rescue e
+    "rescued"
+  end
+end
+println(f())
+
+// The captured name lives in the rescue block and nowhere else.
+let g = func () do
+  var seen = ""
+  try
+    1 / 0
+  rescue e
+    seen = e.message
+  end
+  seen
+end
+println(g())

--- a/testdata/semantics/errors/try-rescue.out
+++ b/testdata/semantics/errors/try-rescue.out
@@ -1,0 +1,11 @@
+caught: division by zero
+42
+boom
+index 10 is out of bounds for length 3
+cannot apply '+' to Int and String
+something went wrong
+<stdlib>/math.ari:64 Math.max() expects a Float or Int
+rethrown: division by zero
+returned through the try
+division by zero
+--- exit: 0

--- a/testdata/semantics/errors/unhandled-failure.ari
+++ b/testdata/semantics/errors/unhandled-failure.ari
@@ -1,0 +1,11 @@
+// A failure nobody catches still halts the program and exits non-zero. `try` is
+// what makes recovery possible, not what makes failure quiet.
+println("before")
+let safe = try
+  1 / 0
+rescue e
+  "handled"
+end
+println(safe)
+println(1 / 0)
+println("after")

--- a/testdata/semantics/errors/unhandled-failure.out
+++ b/testdata/semantics/errors/unhandled-failure.out
@@ -1,0 +1,6 @@
+before
+handled
+unhandled-failure.ari:10:9: error: division by zero
+  println(1 / 0)
+          ^^^^^
+--- exit: 1

--- a/testdata/semantics/stdlib/dict-key-identity.out
+++ b/testdata/semantics/stdlib/dict-key-identity.out
@@ -3,5 +3,5 @@ true
 1
 false
 true
-[=>]
+[:ok, [=>]]
 --- exit: 0

--- a/testdata/semantics/stdlib/dict-results.ari
+++ b/testdata/semantics/stdlib/dict-results.ari
@@ -1,0 +1,24 @@
+// Dict.insert, update and delete used to panic on the ordinary case, so the only
+// way to avoid it was to duplicate the check before every call. A key that is
+// already there, or one that is not, is an outcome a caller should be able to
+// handle.
+let d = [:a => 1]
+println(Dict.insert(d, :b, 2))
+println(Dict.insert(d, :a, 9))
+println(Dict.update(d, :a, 9))
+println(Dict.update(d, :zz, 9))
+println(Dict.delete(d, :a))
+println(Dict.delete(d, :zz))
+
+// A caller who knows the key's state says so; one with a default says that.
+println(Result.expect(Dict.insert(d, :b, 2)))
+println(Result.unwrap(Dict.delete(d, :zz), d))
+
+println(switch Dict.delete(d, :zz) do
+  case [:ok, let out] then out
+  case [:error, let why] then "could not: #{why}"
+end)
+
+// Passing the wrong kind of thing is still a mistake in the caller, not an
+// outcome, so it raises — and `try` is what catches that.
+println(try Math.max("a", 1) rescue e e.message end)

--- a/testdata/semantics/stdlib/dict-results.out
+++ b/testdata/semantics/stdlib/dict-results.out
@@ -1,0 +1,11 @@
+[:ok, [:a => 1, :b => 2]]
+[:error, "Dictionary key 'a' already exists"]
+[:ok, [:a => 9]]
+[:error, "Dictionary key 'zz' doesn't exist"]
+[:ok, [=>]]
+[:error, "Dictionary key 'zz' doesn't exist"]
+[:a => 1, :b => 2]
+[:a => 1]
+could not: Dictionary key 'zz' doesn't exist
+Math.max() expects a Float or Int
+--- exit: 0

--- a/testdata/semantics/stdlib/result-module.ari
+++ b/testdata/semantics/stdlib/result-module.ari
@@ -1,0 +1,28 @@
+// The tagged-result convention, written down. A fallible operation answers
+// [:ok, value] or [:error, reason], which needs no new syntax: switch with array
+// patterns and `let` capture takes one apart.
+println(Result.ok(1))
+println(Result.error("nope"))
+println(Result.ok?(Result.ok(1)))
+println(Result.ok?(Result.error("x")))
+println(Result.error?(Result.error("x")))
+println(Result.ok?([1, 2]))
+println(Result.ok?(5))
+
+println(Result.unwrap(Result.ok(5), 0))
+println(Result.unwrap(Result.error("x"), 0))
+println(Result.unwrap(Result.error("x")))
+println(Result.reason(Result.error("bad")))
+println(Result.reason(Result.ok(1)))
+println(Result.expect(Result.ok(9)))
+
+// attempt is the bridge between the two shapes: it turns whatever a function
+// raises into an error result.
+println(Result.attempt(() -> 1 / 0))
+println(Result.attempt(() -> 21 * 2))
+
+// And the shape reads well with switch capture.
+println(switch Result.attempt(() -> 1 / 0) do
+  case [:ok, let v] then "got #{v}"
+  case [:error, let why] then "failed: #{why}"
+end)

--- a/testdata/semantics/stdlib/result-module.out
+++ b/testdata/semantics/stdlib/result-module.out
@@ -1,0 +1,17 @@
+[:ok, 1]
+[:error, "nope"]
+true
+false
+true
+false
+false
+5
+0
+nil
+bad
+nil
+9
+[:error, "division by zero"]
+[:ok, 42]
+failed: division by zero
+--- exit: 0


### PR DESCRIPTION
Aria had no way to recover from anything, and that answer wasn't written down anywhere, so it read as an oversight rather than a position. `panic` was terminal, every runtime fault unwound to the top of `Run`, and no Aria code could be defensive — including the standard library, whose own error convention was `panic`.

## The ruling

Aria has recoverable errors, in **both** shapes. They answer different questions.

**A tagged-result convention**, for outcomes a caller should expect: `[:ok, value]` or `[:error, reason]`. No new syntax — `switch` with array patterns and `let` capture, both of which just landed, take one apart. A `Result` module gives the shape a name plus `ok?`, `unwrap` with a fallback, `expect`, `reason`, and `attempt` as the bridge between the two shapes.

**`try ... rescue e ... end`**, for genuine faults. An expression, like everything else: it evaluates to whichever block ran.

- **Every runtime error is catchable**, the runtime's own included. The line between a fault and an expected failure is the *caller's* to draw — the same division by zero is a bug in one program and a validation outcome in another. Parse and resolve failures are not catchable: the program never started.
- **A control signal is not a failure**, so a `return` inside a `try` unwinds to its function as usual.
- **The rescued value is a dictionary** — `:message`, `:file`, `:line`, `:column`. The message is what a program usually wants; where it happened is what lets a rescue report anything useful. The name is optional.
- Catching restores the frame stack and clears any control transfer in flight, so a caught failure leaves the interpreter counting from where it was.

## Where the library draws the line

`Dict.insert`, `update` and `delete` answer tagged results — a key that is or isn't there is an ordinary outcome, and the only way to avoid the old panic was to duplicate the check before every call. Passing the wrong *kind* of thing (`Math.max("a", 1)`) still raises: that's a mistake in the caller. **Data versus misuse**, written down.

A failure nobody catches still halts and exits non-zero. `try` makes recovery possible, not failure quiet.

## Cases

`errors/try-rescue`, `errors/try-rescue-scope`, `errors/unhandled-failure`, `stdlib/result-module`, `stdlib/dict-results`, plus Go tests. Two goldens changed: `stdlib/dict-key-identity` sees a tagged `Dict.delete`, and `errors/stdlib-runtime-error` swaps its trigger to `Math.max` — one of the panics that stayed — while still showing that a stdlib fault points into `<stdlib>/*.ari` with the right line and caret.

Closes #15