### PR TITLE
Files, argv, environment and a clock

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# The characterization suite compares exact bytes, and the language job runs on
+# Linux while development happens on whatever. A CRLF checkout would change what
+# a case reads and what its golden says, so the corpus is LF everywhere.
+testdata/** text eol=lf
+internal/stdlib/*.ari text eol=lf
+*.ari text eol=lf
+*.out text eol=lf

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ go test ./internal/parser/  -run=Fuzz -fuzz=FuzzParse -fuzztime=30s
 
 ## The characterization suite is the arbiter
 
-`testdata/semantics/` holds 203 `.ari` files, each with a `.out` golden recording exactly
+`testdata/semantics/` holds 206 `.ari` files, each with a `.out` golden recording exactly
 what the interpreter prints and what it exits with.
 
 **If a golden changes, you changed the language.** That is either the point of your change

--- a/README.md
+++ b/README.md
@@ -1420,6 +1420,44 @@ println(Result.attempt(() -> 1 / 0))
 
 The library draws the line at data versus misuse. `Dict.insert`, `Dict.update` and `Dict.delete` answer tagged results, because a key that is or isn't there is an ordinary outcome. Passing the wrong kind of thing — `Math.max("a", 1)` — still raises, because that's a mistake in the caller.
 
+## Files, Arguments, Environment and Time
+
+`prompt` used to be the only way an Aria program could reach the outside world. `File`, `OS` and `Time` are the rest of it.
+
+Everything that can fail answers a tagged result, so a file that isn't there is something you handle rather than something that ends the program:
+
+```swift
+let path = "config.txt"
+println(switch File.read(path)
+case [:ok, let contents] then "read #{String.count(contents)} characters"
+case [:error, let why] then "could not read: #{why}"
+end)
+```
+
+`File` has `read`, `lines`, `write`, `append`, `remove` and `exists?`. `OS.args()` is everything after the source file on the command line, and `OS.env(name, fallback)` reads the environment:
+
+```
+aria run script.ari one two
+```
+
+```swift
+println(OS.args())
+println(OS.env("HOME", "unknown"))
+```
+
+`Time` has two clocks, because they answer different questions. `Time.now()` is milliseconds since the Unix epoch, which is what you write down. `Time.monotonic()` is nanoseconds from an arbitrary origin, which is what you subtract — a wall clock can move backwards:
+
+```swift
+let start = Time.monotonic()
+var total = 0
+for i in 1..1000
+  total += i
+end
+println(Time.since(start) > 0)
+```
+
+There is no sandbox. A program reads and writes any path the process can, and running untrusted Aria source is running untrusted code.
+
 ## Standard Library
 
 The Standard Library is fully written in Aria with the help of a few essential functions provided by the runtime. That is currently the best source to check out some "production" Aria code and see what it's capable of. [Read the documentation](https://github.com/fadion/aria/wiki/Standard-Library).
@@ -1466,6 +1504,8 @@ println(Dict.get(user, :city, "unknown"))
 ```
 
 **`Result`** — `ok`, `error`, `ok?`, `error?`, `unwrap`, `expect`, `reason`, `attempt`. See [Errors](#errors).
+
+**`File`** — `read`, `lines`, `write`, `append`, `remove`, `exists?`. **`OS`** — `args`, `env`, `env?`. **`Time`** — `now`, `monotonic`, `since`, `milliseconds`, `seconds`.
 
 **`Type`** covers type inspection and conversion.
 

--- a/aria.go
+++ b/aria.go
@@ -39,7 +39,7 @@ func main() {
 	// Without a -e, the default help is what an argument-less invocation wants.
 	app.Action = func(c *cli.Context) error {
 		if src := c.String("eval"); src != "" {
-			runSource(source.NewFile("-e", []byte(src)))
+			runSource(source.NewFile("-e", []byte(src)), c.Args())
 			return nil
 		}
 		return cli.ShowAppHelp(c)
@@ -76,25 +76,25 @@ func main() {
 	}
 }
 
-// readSource reads one argument as a source file. `-` is standard input, so
-// aria can sit in a pipeline.
-func readSource(c *cli.Context, command string) *source.File {
+// readSource reads the first argument as a source file, and returns the rest for
+// the program itself. `-` is standard input, so aria can sit in a pipeline.
+func readSource(c *cli.Context, command string) (*source.File, []string) {
 	args := c.Args()
-	if len(args) != 1 {
+	if len(args) == 0 {
 		// The original printed this and then indexed the empty argument list,
 		// panicking with an index-out-of-range.
-		color.Red("%s expects exactly one source file.", command)
+		color.Red("%s expects a source file.", command)
 		os.Exit(2)
 	}
 
-	path := args[0]
+	path, rest := args[0], []string(args[1:])
 	if path == "-" {
 		src, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			color.Red("Couldn't read standard input")
 			os.Exit(1)
 		}
-		return source.NewFile("<stdin>", src)
+		return source.NewFile("<stdin>", src), rest
 	}
 
 	src, err := os.ReadFile(path)
@@ -102,7 +102,7 @@ func readSource(c *cli.Context, command string) *source.File {
 		color.Red("Couldn't read '%s'", path)
 		os.Exit(1)
 	}
-	return source.NewFile(path, src)
+	return source.NewFile(path, src), rest
 }
 
 func runFile(c *cli.Context) error {
@@ -110,11 +110,13 @@ func runFile(c *cli.Context) error {
 	return nil
 }
 
-func runSource(file *source.File) {
+// runSource evaluates a file with the arguments meant for the program.
+func runSource(file *source.File, args []string) {
 	if !interp.Run(file, interp.Options{
-		Out: os.Stdout,
-		Err: os.Stderr,
-		In:  os.Stdin,
+		Out:  os.Stdout,
+		Err:  os.Stderr,
+		In:   os.Stdin,
+		Args: args,
 	}) {
 		// A failed run exits non-zero, so a script or CI can tell. The original
 		// exited 0 on every parse and runtime error alike.
@@ -123,7 +125,8 @@ func runSource(file *source.File) {
 }
 
 func checkFile(c *cli.Context) error {
-	if !interp.Check(readSource(c, "Check"), interp.Options{Err: os.Stderr}) {
+	file, _ := readSource(c, "Check")
+	if !interp.Check(file, interp.Options{Err: os.Stderr}) {
 		os.Exit(1)
 	}
 	return nil

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -704,7 +704,7 @@ something the author of an Aria program can act on.
 
 ## The characterization suite
 
-`testdata/semantics/` holds 203 cases. Each `.ari` file has a `.out` golden recording
+`testdata/semantics/` holds 206 cases. Each `.ari` file has a `.out` golden recording
 exactly what the interpreter prints and what it exits with.
 
 ```bash
@@ -731,6 +731,38 @@ instead.
 compared case by case. With it unset the runner uses a binary in the repo root if there is
 one, and otherwise builds a throwaway — so the suite runs from a clean checkout with no
 setup, and leaves nothing behind.
+
+## Reaching the outside world
+
+`prompt` was the only way an Aria program could: no files, no arguments, no environment, no
+clock. A program could not read the file it was meant to process, could not be told which
+file that was, and could not report how long it took.
+
+`File`, `OS` and `Time` follow the pattern the rest of the library already does — `runtime_*`
+builtins for what Aria cannot express, and an Aria surface over them — so the library stays
+readable and the Go surface stays small.
+
+**The builtins raise; the library wraps.** `runtime_read_file` fails the way anything else
+in the evaluator does, and `File.read` turns that into a tagged result with `try`. That
+keeps the convention in Aria, where it is written down, rather than duplicated in Go — and
+it is why this came after the error model rather than before it. Adding IO first would have
+baked `panic` into the one place it hurts most.
+
+**Recognised file errors get fixed text**, not the operating system's. "no such file or
+directory" against "The system cannot find the file specified." is a difference that would
+otherwise leak into anything comparing output, this repository's own goldens included.
+
+**Two clocks, because they answer different questions.** `Time.now` is milliseconds since
+the Unix epoch, which is what you write down; `Time.monotonic` is nanoseconds from an
+arbitrary origin, which is what you subtract. Only the second is safe to subtract, since a
+wall clock can move backwards. Both are `Int`s: a `Float` would start losing nanoseconds
+somewhere around 1970 plus a decade. Neither is in the characterization suite, which runs
+every case seven times and would flag them.
+
+**Sandboxing.** There is none, and that is now worth saying out loud. A program can read and
+write any path the process can, `import` reaches any path it is given, and the CLI runs
+whatever source it is handed. Aria is a toy language; running untrusted Aria source is
+running untrusted code, and nothing here pretends otherwise.
 
 ## The tools
 

--- a/internal/interp/builtins.go
+++ b/internal/interp/builtins.go
@@ -1,13 +1,17 @@
 package interp
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"math"
 	"math/rand/v2"
+	"os"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	"github.com/fadion/aria/internal/source"
@@ -399,6 +403,106 @@ func (i *Interp) installBuiltins() {
 		return value.String(strings.ToUpper(ip.wantString("runtime_toupper", args, span)))
 	})
 
+	// ---------------------------------------------------------------------
+	// The outside world
+	// ---------------------------------------------------------------------
+	//
+	// prompt was the only way an Aria program could reach it: no files, no
+	// arguments, no environment, no clock. A program could not read the file it
+	// was meant to process, could not be told which file that was, and could not
+	// report how long it took.
+	//
+	// These raise on failure and the library wraps them into tagged results,
+	// which keeps the convention in Aria where it is written down rather than
+	// duplicated in Go.
+	def("runtime_read_file", func(ip *Interp, args []value.Value, span source.Span) value.Value {
+		path := ip.wantString("runtime_read_file", args, span)
+		src, err := os.ReadFile(path)
+		if err != nil {
+			ip.fail(span, "%s", ioMessage(err))
+		}
+		return value.String(string(src))
+	})
+
+	def("runtime_write_file", func(ip *Interp, args []value.Value, span source.Span) value.Value {
+		path, contents := ip.wantTwoStrings("runtime_write_file", args, span)
+		if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+			ip.fail(span, "%s", ioMessage(err))
+		}
+		return value.String(path)
+	})
+
+	def("runtime_append_file", func(ip *Interp, args []value.Value, span source.Span) value.Value {
+		path, contents := ip.wantTwoStrings("runtime_append_file", args, span)
+		f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+		if err != nil {
+			ip.fail(span, "%s", ioMessage(err))
+		}
+		_, writeErr := f.WriteString(contents)
+		closeErr := f.Close()
+		// A close error on a write is a real failure — the bytes may not have
+		// reached the file — so it is reported when the write itself did not.
+		if writeErr != nil {
+			ip.fail(span, "%s", ioMessage(writeErr))
+		}
+		if closeErr != nil {
+			ip.fail(span, "%s", ioMessage(closeErr))
+		}
+		return value.String(path)
+	})
+
+	def("runtime_remove_file", func(ip *Interp, args []value.Value, span source.Span) value.Value {
+		path := ip.wantString("runtime_remove_file", args, span)
+		if err := os.Remove(path); err != nil {
+			ip.fail(span, "%s", ioMessage(err))
+		}
+		return value.String(path)
+	})
+
+	def("runtime_file_exists", func(ip *Interp, args []value.Value, span source.Span) value.Value {
+		_, err := os.Stat(ip.wantString("runtime_file_exists", args, span))
+		return value.Of(err == nil)
+	})
+
+	// The arguments after the source file. The CLI keeps its own flags.
+	def("runtime_args", func(ip *Interp, args []value.Value, span source.Span) value.Value {
+		ip.wantArgs("runtime_args", args, 0, span)
+		out := make([]value.Value, 0, len(ip.args))
+		for _, a := range ip.args {
+			out = append(out, value.String(a))
+		}
+		return value.NewArray(out)
+	})
+
+	// nil for an unset variable, so `OS.env("PORT") ?? "8080"` reads the way it
+	// should. An empty variable is set, and answers "".
+	def("runtime_env", func(ip *Interp, args []value.Value, span source.Span) value.Value {
+		v, ok := os.LookupEnv(ip.wantString("runtime_env", args, span))
+		if !ok {
+			return value.NilValue
+		}
+		return value.String(v)
+	})
+
+	def("runtime_env_set", func(ip *Interp, args []value.Value, span source.Span) value.Value {
+		_, ok := os.LookupEnv(ip.wantString("runtime_env_set", args, span))
+		return value.Of(ok)
+	})
+
+	// Two clocks, because they answer different questions. Milliseconds since
+	// the Unix epoch is a stamp; nanoseconds from an arbitrary origin is a
+	// duration, and only the second one is safe to subtract. Both are Ints: a
+	// Float would lose nanoseconds somewhere around 1970 plus a decade.
+	def("runtime_now_ms", func(ip *Interp, args []value.Value, span source.Span) value.Value {
+		ip.wantArgs("runtime_now_ms", args, 0, span)
+		return value.Int(time.Now().UnixMilli())
+	})
+
+	def("runtime_monotonic_ns", func(ip *Interp, args []value.Value, span source.Span) value.Value {
+		ip.wantArgs("runtime_monotonic_ns", args, 0, span)
+		return value.Int(int64(time.Since(processStart)))
+	})
+
 	def("runtime_regex_match", func(ip *Interp, args []value.Value, span source.Span) value.Value {
 		ip.wantArgs("runtime_regex_match", args, 2, span)
 		subject, ok1 := args[0].(value.String)
@@ -412,6 +516,47 @@ func (i *Interp) installBuiltins() {
 		}
 		return value.Of(re.MatchString(string(subject)))
 	})
+}
+
+// processStart is the origin of the monotonic clock. Go's own monotonic reading
+// is only exposed as a difference, so the origin has to be captured once.
+var processStart = time.Now()
+
+// ioMessage renders a file error.
+//
+// The recognised conditions get fixed text rather than the operating system's,
+// which differs per platform — "no such file or directory" against "The system
+// cannot find the file specified." — and would otherwise leak into anything that
+// compares output, this repository's own goldens included.
+func ioMessage(err error) string {
+	path := ""
+	var pathErr *fs.PathError
+	if errors.As(err, &pathErr) {
+		path = pathErr.Path + ": "
+	}
+
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		return path + "no such file"
+	case errors.Is(err, fs.ErrPermission):
+		return path + "permission denied"
+	case errors.Is(err, fs.ErrExist):
+		return path + "already exists"
+	}
+	if pathErr != nil {
+		return path + pathErr.Err.Error()
+	}
+	return err.Error()
+}
+
+func (i *Interp) wantTwoStrings(name string, args []value.Value, span source.Span) (string, string) {
+	i.wantArgs(name, args, 2, span)
+	first, ok1 := args[0].(value.String)
+	second, ok2 := args[1].(value.String)
+	if !ok1 || !ok2 {
+		i.fail(span, "%s() expects two Strings", name)
+	}
+	return string(first), string(second)
 }
 
 // orderOf compares two values the way `<` does — numbers among numbers, text

--- a/internal/interp/interp.go
+++ b/internal/interp/interp.go
@@ -109,6 +109,8 @@ type Interp struct {
 	dir string
 	// imported guards against re-importing, matching the original's cache.
 	imported map[string]bool
+	// args is what the program was told, everything after the source file.
+	args []string
 
 	signal signal
 	retval value.Value

--- a/internal/interp/interp_test.go
+++ b/internal/interp/interp_test.go
@@ -2,6 +2,7 @@ package interp_test
 
 import (
 	"errors"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -2007,6 +2008,108 @@ func TestResultConvention(t *testing.T) {
 
 	// Passing the wrong kind of thing still raises.
 	if got := withStdlib(t, `println(try Math.max("a", 1) rescue e e.message end)`); got != "Math.max() expects a Float or Int" {
+		t.Errorf("got %q", got)
+	}
+}
+
+// prompt was the only way an Aria program could reach the outside world: no
+// files, no arguments, no environment, no clock.
+func TestFileIO(t *testing.T) {
+	dir := t.TempDir()
+	path := strings.ReplaceAll(filepath.Join(dir, "note.txt"), `\`, `\\`)
+
+	src := `let path = "` + path + `"
+println(File.exists?(path))
+println(File.write(path, "one\ntwo\n"))
+println(File.exists?(path))
+println(File.read(path))
+println(File.lines(path))
+println(File.append(path, "three\n"))
+println(File.lines(path))
+println(File.remove(path))
+println(File.exists?(path))`
+
+	want := strings.Join([]string{
+		"false",
+		`[:ok, "` + path + `"]`,
+		"true",
+		`[:ok, "one\ntwo\n"]`,
+		`[:ok, ["one", "two"]]`,
+		`[:ok, "` + path + `"]`,
+		`[:ok, ["one", "two", "three"]]`,
+		`[:ok, "` + path + `"]`,
+		"false",
+	}, "\n")
+
+	if got := withStdlib(t, src); got != want {
+		t.Errorf("got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// A file that is not there is the canonical thing a caller should be able to
+// handle, and the recognised conditions get platform-independent text.
+func TestFileMissing(t *testing.T) {
+	tests := []struct{ src, want string }{
+		{`println(File.read("_no_such_file_xyz.txt"))`, `[:error, "_no_such_file_xyz.txt: no such file"]`},
+		{`println(File.exists?("_no_such_file_xyz.txt"))`, "false"},
+		{`println(Result.unwrap(File.read("_no_such_file_xyz.txt"), "fallback"))`, "fallback"},
+		{`println(Result.ok?(File.remove("_no_such_file_xyz.txt")))`, "false"},
+	}
+	for _, test := range tests {
+		if got := withStdlib(t, test.src); got != test.want {
+			t.Errorf("%s: got %q, want %q", test.src, got, test.want)
+		}
+	}
+}
+
+// Everything after the source file reaches the program; the CLI keeps its flags.
+func TestArgsAndEnv(t *testing.T) {
+	var out, errOut strings.Builder
+	_, err := interp.Eval("test.ari", `println(OS.args())
+println(Enum.size(OS.args()))`, interp.Options{
+		Out: &out, Err: &errOut, In: strings.NewReader(""),
+		Args: []string{"one", "two"},
+	})
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	if out.String() != "[\"one\", \"two\"]\n2\n" {
+		t.Errorf("got %q", out.String())
+	}
+
+	t.Setenv("ARIA_TEST_VAR", "set-value")
+	tests := []struct{ src, want string }{
+		{`println(OS.env("ARIA_TEST_VAR"))`, "set-value"},
+		{`println(OS.env?("ARIA_TEST_VAR"))`, "true"},
+		{`println(OS.env("ARIA_NOT_SET_XYZ", "fallback"))`, "fallback"},
+		{`println(OS.env("ARIA_NOT_SET_XYZ"))`, "nil"},
+		{`println(OS.env?("ARIA_NOT_SET_XYZ"))`, "false"},
+	}
+	for _, test := range tests {
+		if got := withStdlib(t, test.src); got != test.want {
+			t.Errorf("%s: got %q, want %q", test.src, got, test.want)
+		}
+	}
+}
+
+// Two clocks, because they answer different questions. Only the monotonic one is
+// safe to subtract, and neither belongs in the characterization suite.
+func TestClocks(t *testing.T) {
+	if got := withStdlib(t, `println(Time.now() > 1600000000000)`); got != "true" {
+		t.Errorf("wall clock reads %q", got)
+	}
+	if got := withStdlib(t, `let start = Time.monotonic()
+var total = 0
+for i in 1..50000
+  total += i
+end
+println(Time.since(start) > 0)`); got != "true" {
+		t.Errorf("monotonic clock reads %q", got)
+	}
+	if got := withStdlib(t, `println(Time.milliseconds(5000000))`); got != "5" {
+		t.Errorf("got %q", got)
+	}
+	if got := withStdlib(t, `println(Time.seconds(1500000000))`); got != "1.5" {
 		t.Errorf("got %q", got)
 	}
 }

--- a/internal/interp/run.go
+++ b/internal/interp/run.go
@@ -21,6 +21,9 @@ type Options struct {
 	Out io.Writer
 	Err io.Writer
 	In  io.Reader
+	// Args is what the program was told: everything after the source file. The
+	// CLI keeps its own flags.
+	Args []string
 	// NoStdlib skips loading the standard library, for tests that want a bare
 	// interpreter.
 	NoStdlib bool
@@ -47,6 +50,7 @@ func Run(file *source.File, opts Options) bool {
 
 	i := New(file, nil)
 	i.Out, i.Err, i.In = opts.Out, opts.Err, opts.In
+	i.args = opts.Args
 
 	// The standard library is compiled and evaluated first, into the same
 	// globals the program will use. Doing it once here rather than on every
@@ -205,6 +209,7 @@ func Eval(name, src string, opts Options) (value.Value, error) {
 	if opts.In != nil {
 		i.In = opts.In
 	}
+	i.args = opts.Args
 
 	if !opts.NoStdlib {
 		var sink discard

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -43,6 +43,10 @@ var Builtins = []string{
 	"runtime_split", "runtime_replace",
 	"runtime_join", "runtime_repeat", "runtime_reverse",
 	"runtime_sort", "runtime_has_key",
+	"runtime_read_file", "runtime_write_file", "runtime_append_file",
+	"runtime_remove_file", "runtime_file_exists",
+	"runtime_args", "runtime_env", "runtime_env_set",
+	"runtime_now_ms", "runtime_monotonic_ns",
 }
 
 // Kind is what introduced a binding.

--- a/internal/stdlib/file.ari
+++ b/internal/stdlib/file.ari
@@ -1,0 +1,55 @@
+// File reads and writes whole files by path.
+//
+// Every operation that can fail answers a tagged result rather than raising: a
+// file that is not there is the canonical thing a caller should be able to
+// handle, and it is the whole reason the error model exists. See
+// docs/architecture.md.
+//
+// Streaming is not here. Whole-file access is what a script needs, and a stream
+// wants a handle type the language does not have yet.
+module File
+
+  let read = func (path: String) -> Array
+    try
+      Result.ok(runtime_read_file(path))
+    rescue e
+      Result.error(e.message)
+    end
+  end
+
+  let lines = func (path: String) -> Array
+    switch File.read(path)
+    case [:ok, let contents] then Result.ok(String.lines(contents))
+    case [:error, let why] then Result.error(why)
+    end
+  end
+
+  let write = func (path: String, contents: String) -> Array
+    try
+      Result.ok(runtime_write_file(path, contents))
+    rescue e
+      Result.error(e.message)
+    end
+  end
+
+  let append = func (path: String, contents: String) -> Array
+    try
+      Result.ok(runtime_append_file(path, contents))
+    rescue e
+      Result.error(e.message)
+    end
+  end
+
+  let remove = func (path: String) -> Array
+    try
+      Result.ok(runtime_remove_file(path))
+    rescue e
+      Result.error(e.message)
+    end
+  end
+
+  let exists? = func (path: String) -> Bool
+    runtime_file_exists(path)
+  end
+
+end

--- a/internal/stdlib/os.ari
+++ b/internal/stdlib/os.ari
@@ -1,0 +1,24 @@
+// OS is what the program was told and what it was started in.
+module OS
+
+  // args is everything after the source file. The CLI keeps its own flags, so a
+  // program sees only what was meant for it.
+  let args = func () -> Array
+    runtime_args()
+  end
+
+  // env answers the fallback for a variable that is not set, which `dict[key]`
+  // could not express: an empty variable IS set, and answers "".
+  let env = func (name: String, fallback = nil)
+    let found = runtime_env(name)
+    if found == nil
+      return fallback
+    end
+    found
+  end
+
+  let env? = func (name: String) -> Bool
+    runtime_env_set(name)
+  end
+
+end

--- a/internal/stdlib/string.ari
+++ b/internal/stdlib/string.ari
@@ -200,9 +200,16 @@ module String
     runtime_last_index_of(str, search)
   end
 
+  // A trailing newline ends the last line rather than starting an empty one,
+  // which is what makes this usable on a file that ends the way files do.
   let lines = func (str: String) -> Array
-    String.split(String.replace(str, "\r\n", "\n"), "\n")
+    let split = String.split(String.replace(str, "\r\n", "\n"), "\n")
+    let size = Enum.size(split)
+    if size > 0 && split[size - 1] == ""
+      return Enum.take(split, size - 1)
     end
+    split
+  end
 
   // words splits on runs of whitespace, so repeated separators do not produce
   // empty entries the way split on a single space would.

--- a/internal/stdlib/time.ari
+++ b/internal/stdlib/time.ari
@@ -1,0 +1,33 @@
+// Time has two clocks, because they answer different questions.
+//
+// `now` is a stamp: milliseconds since the Unix epoch, which is what you write
+// down. `monotonic` is a duration source: nanoseconds from an arbitrary origin,
+// which is what you subtract. Only the second one is safe to subtract, since a
+// wall clock can move backwards.
+//
+// Both are Ints. A Float would start losing nanoseconds somewhere around 1970
+// plus a decade.
+module Time
+
+  let now = func () -> Int
+    runtime_now_ms()
+  end
+
+  let monotonic = func () -> Int
+    runtime_monotonic_ns()
+  end
+
+  // since answers the nanoseconds elapsed since a monotonic reading.
+  let since = func (start: Int) -> Int
+    runtime_monotonic_ns() - start
+  end
+
+  let milliseconds = func (nanoseconds: Int) -> Int
+    nanoseconds / 1000000
+  end
+
+  let seconds = func (nanoseconds: Int) -> Float
+    Float(nanoseconds) / 1000000000.0
+  end
+
+end

--- a/testdata/semantics/runtime/_fixture.txt
+++ b/testdata/semantics/runtime/_fixture.txt
@@ -1,0 +1,2 @@
+first line
+second line

--- a/testdata/semantics/runtime/file-missing.ari
+++ b/testdata/semantics/runtime/file-missing.ari
@@ -1,0 +1,10 @@
+// The recognised conditions get fixed text rather than the operating system's,
+// which differs per platform and would otherwise leak into anything comparing
+// output — these goldens included.
+println(File.read("_no_such_file.txt"))
+println(File.exists?("_no_such_file.txt"))
+println(Result.unwrap(File.read("_no_such_file.txt"), "a default"))
+println(switch File.read("_no_such_file.txt") do
+  case [:ok, let contents] then contents
+  case [:error, let why] then "could not read: #{why}"
+end)

--- a/testdata/semantics/runtime/file-missing.out
+++ b/testdata/semantics/runtime/file-missing.out
@@ -1,0 +1,5 @@
+[:error, "_no_such_file.txt: no such file"]
+false
+a default
+could not read: _no_such_file.txt: no such file
+--- exit: 0

--- a/testdata/semantics/runtime/file-read.ari
+++ b/testdata/semantics/runtime/file-read.ari
@@ -1,0 +1,9 @@
+// prompt was the only way an Aria program could reach the outside world: no
+// files, no arguments, no environment, no clock. A program could not read the
+// file it was meant to process.
+//
+// Everything that can fail answers a tagged result rather than raising: a file
+// that is not there is the canonical thing a caller should be able to handle.
+println(File.read("_fixture.txt"))
+println(File.lines("_fixture.txt"))
+println(File.exists?("_fixture.txt"))

--- a/testdata/semantics/runtime/file-read.out
+++ b/testdata/semantics/runtime/file-read.out
@@ -1,0 +1,4 @@
+[:ok, "first line\nsecond line\n"]
+[:ok, ["first line", "second line"]]
+true
+--- exit: 0

--- a/testdata/semantics/runtime/os-args.ari
+++ b/testdata/semantics/runtime/os-args.ari
@@ -1,0 +1,11 @@
+// The arguments after the source file. The CLI keeps its own flags, so a program
+// sees only what was meant for it — which here is nothing, since the runner
+// passes none.
+println(OS.args())
+println(Enum.size(OS.args()))
+
+// env answers the fallback for a variable that is not set, which a dictionary
+// lookup could not express: an empty variable IS set, and answers "".
+println(OS.env("ARIA_DEFINITELY_NOT_SET_XYZ", "fallback"))
+println(OS.env("ARIA_DEFINITELY_NOT_SET_XYZ"))
+println(OS.env?("ARIA_DEFINITELY_NOT_SET_XYZ"))

--- a/testdata/semantics/runtime/os-args.out
+++ b/testdata/semantics/runtime/os-args.out
@@ -1,0 +1,6 @@
+[]
+0
+fallback
+nil
+false
+--- exit: 0


### PR DESCRIPTION
`prompt` was the only way an Aria program could reach the outside world — no files, no arguments, no environment, no clock. A program could not read the file it was meant to process, could not be told which file that was, and could not report how long it took.

## What changed

- **`File`** — `read`, `lines`, `write`, `append`, `remove`, `exists?`. **`OS`** — `args`, `env` with a fallback, `env?`. **`Time`** — `now`, `monotonic`, `since`, `milliseconds`, `seconds`.
- They follow the pattern the rest of the library does: `runtime_*` builtins for what Aria can't express, an Aria surface over them.
- **The builtins raise; the library wraps.** `File.read` turns a failure into a tagged result with `try`, which keeps the convention in Aria where it's written down rather than duplicated in Go. This is why it waited for #15 — reading a missing file is *the* canonical recoverable error, and with only `panic` available every IO function would be unusable in exactly the situation it exists for.
- **Recognised file errors get fixed text**, not the OS's: "no such file or directory" against "The system cannot find the file specified." would otherwise leak into anything comparing output. `.gitattributes` now pins the corpus to LF for the same reason.
- **Two clocks.** `Time.now` is a stamp (ms since the epoch); `Time.monotonic` is a duration source (ns from an arbitrary origin) and the only one safe to subtract. Both `Int`, since a `Float` loses nanoseconds. Neither is in the characterization suite — the runner runs every case seven times and would flag them — so Go tests cover them.
- The CLI passes everything after the source file through to the program.
- **One incidental fix**: `String.lines` drops a trailing empty line, without which `File.lines` returns a phantom last line for any file ending the way files do.
- **A sandboxing note** in `docs/architecture.md`: there is none, and running untrusted Aria source is running untrusted code.

`runtime/file-read`, `runtime/file-missing` and `runtime/os-args` added with a fixture, plus Go tests for the write path and both clocks. No existing golden changed.

Closes #25