### PR TITLE
Records, so structured data has a home

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ go test ./internal/parser/  -run=Fuzz -fuzz=FuzzParse -fuzztime=30s
 
 ## The characterization suite is the arbiter
 
-`testdata/semantics/` holds 212 `.ari` files, each with a `.out` golden recording exactly
+`testdata/semantics/` holds 219 `.ari` files, each with a `.out` golden recording exactly
 what the interpreter prints and what it exits with.
 
 **If a golden changes, you changed the language.** That is either the point of your change

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ println(pipe) // "Expressive Aria Language"
 * [Pipe Operator](#pipe-operator)
 * [Immutability](#immutability)
 * [Modules](#modules)
+* [Records](#records)
 * [Imports](#imports)
 * [Comments](#comments)
 * [Standard Library](#standard-library)
@@ -1255,7 +1256,7 @@ Think first of how you would write the problem with immutable values and only mo
 
 ## Modules
 
-Modules are very simple containers of data and nothing more. They're not an imitation of classes, as they can't be initialized, don't have any type of access control, inheritance or whatever. If you need to think in Object Oriented terms, they're like a class with only static properties and methods. They're good to give some structure to a program, but not to represent cars, trees and cats.
+Modules are very simple containers of data and nothing more. They're not an imitation of classes, as they can't be initialized, don't have any type of access control, inheritance or whatever. If you need to think in Object Oriented terms, they're like a class with only static properties and methods. They're good to give some structure to a program, but not to represent cars, trees and cats — that's what [records](#records) are for.
 
 ```swift
 module Color
@@ -1302,6 +1303,60 @@ And `.` is an operator over expressions rather than a form over two names, so it
 let config = [:db => [:host => "localhost"]]
 println(config.db.host)
 ```
+
+## Records
+
+Modules give a program structure but can't be instantiated, and a dictionary carries data without any identity — `typeof` says `Dictionary` for every one of them. A record is the shape for a car, a tree or a cat.
+
+```swift
+record Point
+  x: Int
+  y: Int
+end
+
+let p = Point(1, 2)
+println(p.x)
+println(typeof(p))  // "Point"
+println(p is Point) // true
+```
+
+A record's fields are a parameter list, so constructing one is an ordinary call — same arity check, same type hints, same defaults:
+
+```swift
+record Config
+  host: String
+  port: Int = 8080
+end
+println(Config("localhost"))
+```
+
+Two records with the same fields are still different types, which is the whole point of having one:
+
+```swift
+record Point
+  x: Int
+end
+record Size
+  x: Int
+end
+println(Point(1) == Size(1)) // false
+```
+
+Records are immutable like everything else, so writing a field rebinds the name — the same reading `a[0] = v` already has:
+
+```swift
+record Point
+  x: Int
+  y: Int
+end
+var p = Point(1, 2)
+let before = p
+p.x = 5
+println(p)      // Point(x: 5, y: 2)
+println(before) // Point(x: 1, y: 2)
+```
+
+That works through dictionaries too, and to any depth.
 
 ## Imports
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -502,6 +502,43 @@ spends a section on. A count needs no new token, where a label would; it reads p
 two, but two is the case that comes up. The resolver counts the loops a `break` is inside,
 so `break 3` inside two is a diagnostic rather than an unwind out of the enclosing function.
 
+## Records: structured data has a home
+
+Anything shaped like a domain object had none. A module holds only `let` and cannot be
+instantiated — the README says so — and a dictionary carries data but no identity, so
+`typeof` reported `Dictionary` for every one of them and `is` could not tell a point from a
+config. Structured data was untyped dictionaries, checked by hand.
+
+**A record's fields are a parameter list**, so constructing one is an ordinary call:
+`Point(1, 2)`, with the same arity check, the same type hints and the same defaults every
+other call has. That is why a record needs no construction syntax of its own, and a field
+needs no syntax that a parameter did not already have.
+
+*Named construction is deliberately not here.* `Point(x: 1, y: 2)` would be a change to
+every call in the language, not a record feature, and it is worth making once for all calls
+rather than only where records happen to need it.
+
+**Identity is the point.** `typeof` reports the record's own name and `is` tests against it,
+so `p is Point` is true and `p is Dictionary` is false. Two records with the same field
+values are still different types: `Point(1, 2) == Size(1, 2)` is false, which is what having
+a type is for. `value.TypeName` is the one place that answers this, and everything that
+compares a type name goes through it — `typeof`, `is`, parameter hints, return hints, case
+types, the reassignment type lock.
+
+**Update returns a new record.** `p.x = 5` rebinds `p`, which is the reading `a[0] = v`
+already had under the frozen-collections rule, so a record is not a new kind of thing here.
+It nests through records and dictionaries alike, and a `let`-bound record cannot be written
+through for the same reason a `let`-bound array cannot. Field assignment on a dictionary
+falls out of the same code, and works now where it did not before.
+
+**A missing field is a runtime error naming the record**, and an unknown field on a
+declaration is caught where it is written. Records are hoisted like modules, so the order of
+two declarations does not matter.
+
+**Destructuring a record by field is not here.** It needs the same spelling dictionary
+destructuring needs — binding by name rather than by position — and both are worth deciding
+together. Field access plus `case is Point` covers matching in the meantime.
+
 ## `let` marks binding, everywhere
 
 `for k, v` was the only multi-bind in the language: there was no way to take an array apart
@@ -704,7 +741,7 @@ something the author of an Aria program can act on.
 
 ## The characterization suite
 
-`testdata/semantics/` holds 212 cases. Each `.ari` file has a `.out` golden recording
+`testdata/semantics/` holds 219 cases. Each `.ari` file has a `.out` golden recording
 exactly what the interpreter prints and what it exits with.
 
 ```bash

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -642,6 +642,25 @@ func (n *Access) Inspect() string {
 	return n.Left.Inspect() + dot + n.Name.Inspect()
 }
 
+// Record declares a named set of fields.
+//
+// Fields reuse FunctionParameter, because a field and a parameter are the same
+// shape — a name, an optional type hint, an optional default — and a record's
+// constructor is a call.
+type Record struct {
+	Base
+	Name   *Identifier
+	Fields []*FunctionParameter
+}
+
+func (n *Record) Inspect() string {
+	parts := make([]string, 0, len(n.Fields))
+	for _, f := range n.Fields {
+		parts = append(parts, f.Inspect())
+	}
+	return "record " + inspectOr(n.Name, "") + " " + strings.Join(parts, ", ") + " end"
+}
+
 // Import splices another source file into this scope.
 type Import struct {
 	Base

--- a/internal/ast/walk.go
+++ b/internal/ast/walk.go
@@ -166,6 +166,13 @@ func Children(n Node) []Node {
 	case *Module:
 		ident(n.Name)
 		block(n.Body)
+	case *Record:
+		ident(n.Name)
+		for _, f := range n.Fields {
+			if f != nil {
+				out = append(out, f)
+			}
+		}
 	case *Access:
 		node(n.Left)
 		ident(n.Name)

--- a/internal/interp/builtins.go
+++ b/internal/interp/builtins.go
@@ -62,7 +62,9 @@ func (i *Interp) installBuiltins() {
 
 	def("typeof", func(ip *Interp, args []value.Value, span source.Span) value.Value {
 		ip.wantArgs("typeof", args, 1, span)
-		return value.String(args[0].Type().String())
+		// TypeName, not Type().String(): a record answers its own name, which
+		// is the whole point of it having one.
+		return value.String(value.TypeName(args[0]))
 	})
 
 	def("String", func(ip *Interp, args []value.Value, span source.Span) value.Value {

--- a/internal/interp/callable.go
+++ b/internal/interp/callable.go
@@ -102,6 +102,10 @@ func (i *Interp) apply(callee value.Value, args []value.Value, span source.Span,
 		if fn.call != nil {
 			return fn.call.Fn(i, args, span)
 		}
+	case *RecordDef:
+		// A record's fields are a parameter list, so constructing one is an
+		// ordinary call. That is why a record needs no construction syntax.
+		return i.construct(fn, args, span)
 	}
 	i.fail(span, "cannot call %s", callee.Type())
 	return value.NilValue
@@ -177,9 +181,9 @@ func (i *Interp) callFunction(fn *Function, args []value.Value, span source.Span
 	}
 
 	if decl.ReturnType != nil && decl.ReturnType.Value != value.Any &&
-		result.Type().String() != decl.ReturnType.Value {
+		value.TypeName(result) != decl.ReturnType.Value {
 		i.failIn(callerFile, span, "%s declares it returns %s but returned %s",
-			fnName(decl), decl.ReturnType.Value, result.Type())
+			fnName(decl), decl.ReturnType.Value, value.TypeName(result))
 	}
 	return result
 }
@@ -188,8 +192,9 @@ func (i *Interp) checkParamType(p *ast.FunctionParameter, arg value.Value, file 
 	if p.Type == nil || p.Type.Value == value.Any {
 		return
 	}
-	if arg.Type().String() != p.Type.Value {
-		i.failIn(file, span, "parameter '%s' expects %s, got %s", p.Name.Value, p.Type.Value, arg.Type())
+	if value.TypeName(arg) != p.Type.Value {
+		i.failIn(file, span, "parameter '%s' expects %s, got %s",
+			p.Name.Value, p.Type.Value, value.TypeName(arg))
 	}
 }
 
@@ -260,6 +265,12 @@ func (i *Interp) evalAccess(n *ast.Access, e *env) value.Value {
 	}
 
 	switch v := left.(type) {
+	case *value.Record:
+		if member, found := v.Get(n.Name.Value); found {
+			return member
+		}
+		i.fail(n.Name.Span(), "%s has no field '%s'", v.Def.Name, n.Name.Value)
+
 	case *Module:
 		member, found := v.Member(n.Name.Value)
 		if !found {

--- a/internal/interp/interp.go
+++ b/internal/interp/interp.go
@@ -104,6 +104,8 @@ type Interp struct {
 
 	globals *env
 	modules map[string]*Module
+	// records holds the record types declared in this compilation.
+	records map[string]*RecordDef
 	// dir is where relative imports resolve from.
 	dir string
 	// imported guards against re-importing, matching the original's cache.
@@ -147,6 +149,7 @@ func New(file *source.File, info *resolver.Info) *Interp {
 		In:       os.Stdin,
 		globals:  newEnv(nil),
 		modules:  map[string]*Module{},
+		records:  map[string]*RecordDef{},
 		imported: map[string]bool{},
 	}
 	i.dir = filepath.Dir(file.Name)
@@ -317,7 +320,9 @@ func (i *Interp) eval(n ast.Node, e *env) value.Value {
 			i.eval(n.Left, e)
 			return value.True
 		}
-		return value.Of(i.eval(n.Left, e).Type().String() == n.Right.Value)
+		// TypeName, not Type().String(): a record answers its own name, which
+		// is the whole point of it having one.
+		return value.Of(value.TypeName(i.eval(n.Left, e)) == n.Right.Value)
 	case *ast.As:
 		return i.convert(i.eval(n.Left, e), n.Right.Value, n.Span())
 
@@ -375,6 +380,8 @@ func (i *Interp) eval(n ast.Node, e *env) value.Value {
 	case *ast.Module:
 		i.evalModule(n, e)
 		return value.NilValue
+	case *ast.Record:
+		return i.evalRecord(n, e)
 	case *ast.Access:
 		return i.evalAccess(n, e)
 
@@ -425,16 +432,11 @@ func (i *Interp) evalAssign(n *ast.Assign, e *env) value.Value {
 		return rhs
 	}
 
-	sub, ok := n.Name.(*ast.Subscript)
-	if !ok {
-		i.fail(n.Span(), "assignment expects a name on the left")
-	}
-
-	// Under immutable collections a subscript write is a rebinding: build the
-	// updated collection, then assign it back to the name it came from.
-	base, path := flattenSubscript(sub)
+	// Under immutable collections a subscript or field write is a rebinding:
+	// build the updated value, then assign it back to the name it came from.
+	base, path := flattenTarget(n.Name)
 	id, ok := base.(*ast.Identifier)
-	if !ok {
+	if !ok || len(path) == 0 {
 		i.fail(n.Span(), "assignment expects a name on the left")
 	}
 
@@ -448,6 +450,34 @@ func (i *Interp) evalAssign(n *ast.Assign, e *env) value.Value {
 	return rhs
 }
 
+// targetStep is one link of an assignment target: `a[i]` or `a.field`.
+type targetStep struct {
+	index ast.Node
+	field *ast.Identifier
+}
+
+// flattenTarget walks an assignment target down to the name being written
+// through, collecting the links in source order.
+//
+// `p.x = 5` reads the same way `a[0] = v` does — rebind `p` to a new value with
+// one field replaced — which is what the frozen-collections rule already meant
+// for a dictionary, and now also for a record.
+func flattenTarget(n ast.Node) (ast.Node, []targetStep) {
+	var path []targetStep
+	for {
+		switch t := n.(type) {
+		case *ast.Subscript:
+			path = append([]targetStep{{index: t.Index}}, path...)
+			n = t.Left
+		case *ast.Access:
+			path = append([]targetStep{{field: t.Name}}, path...)
+			n = t.Left
+		default:
+			return n, path
+		}
+	}
+}
+
 // assignChecked writes v to name, enforcing the type lock.
 func (i *Interp) assignChecked(id *ast.Identifier, v value.Value, e *env) {
 	old, found := e.lookup(id.Value)
@@ -456,40 +486,51 @@ func (i *Interp) assignChecked(id *ast.Identifier, v value.Value, e *env) {
 	}
 	// Reassignment preserves the original type. Nil is exempt, since a binding
 	// that started nil has no type to preserve.
-	if old.Type() != v.Type() && old.Type() != value.TNil && v.Type() != value.TNil {
+	// TypeName, so two different records do not both read as "Record".
+	if value.TypeName(old) != value.TypeName(v) && old.Type() != value.TNil && v.Type() != value.TNil {
 		i.fail(id.Span(), "'%s' holds %s, so it cannot be assigned %s",
-			id.Value, old.Type(), v.Type())
+			id.Value, value.TypeName(old), value.TypeName(v))
 	}
 	if !e.assign(id.Value, v) {
 		i.fail(id.Span(), "'%s' is not defined", id.Value)
 	}
 }
 
-// flattenSubscript peels nested indexing down to the base name, returning the
-// index expressions outermost-last so a[0][1] can be rebuilt in order.
-func flattenSubscript(s *ast.Subscript) (ast.Node, []ast.Node) {
-	var path []ast.Node
-	var node ast.Node = s
-	for {
-		sub, ok := node.(*ast.Subscript)
-		if !ok {
-			break
-		}
-		path = append([]ast.Node{sub.Index}, path...)
-		node = sub.Left
-	}
-	return node, path
-}
-
 // updatePath returns a copy of container with the value at path replaced.
-func (i *Interp) updatePath(container value.Value, path []ast.Node, v value.Value, e *env, span source.Span) value.Value {
+func (i *Interp) updatePath(container value.Value, path []targetStep, v value.Value, e *env, span source.Span) value.Value {
 	if len(path) == 0 {
 		return v
 	}
 
-	idxNode := path[0]
 	rest := path[1:]
 
+	// A field step, `a.name`, reads whatever is at that name and puts back a
+	// copy with it replaced.
+	if field := path[0].field; field != nil {
+		switch c := container.(type) {
+		case *value.Record:
+			inner, found := c.Get(field.Value)
+			if !found {
+				i.fail(field.Span(), "%s has no field '%s'", c.Def.Name, field.Value)
+			}
+			out, _ := c.With(field.Value, i.updatePath(inner, rest, v, e, span))
+			return out
+
+		case *value.Dict:
+			key := value.String(field.Value)
+			if len(rest) == 0 {
+				return c.With(key, v)
+			}
+			inner, found := c.Get(key)
+			if !found {
+				i.fail(field.Span(), "no key '%s' in the dictionary", field.Value)
+			}
+			return c.With(key, i.updatePath(inner, rest, v, e, span))
+		}
+		i.fail(span, "cannot write '.%s' to %s", field.Value, value.TypeName(container))
+	}
+
+	idxNode := path[0].index
 	switch c := container.(type) {
 	case *value.Array:
 		// An empty index or `_` appends.
@@ -547,7 +588,7 @@ func (i *Interp) updatePath(container value.Value, path []ast.Node, v value.Valu
 		return value.String(string(out))
 	}
 
-	i.fail(span, "cannot index into %s", container.Type())
+	i.fail(span, "cannot index into %s", value.TypeName(container))
 	return value.NilValue
 }
 
@@ -801,7 +842,9 @@ func (i *Interp) caseValueMatches(el ast.Node, control value.Value, e *env) bool
 		if el.Name.Value == value.Any {
 			return true
 		}
-		return control.Type().String() == el.Name.Value
+		// TypeName, so `case is Point` matches a Point rather than every
+		// record.
+		return value.TypeName(control) == el.Name.Value
 
 	case *ast.Array:
 		// An array literal in case position pattern-matches element by element,

--- a/internal/interp/interp_test.go
+++ b/internal/interp/interp_test.go
@@ -2223,3 +2223,118 @@ func TestImportIsTopLevelOnly(t *testing.T) {
 		t.Errorf("got %v", err)
 	}
 }
+
+// Structured data had no home: a module holds only `let` and cannot be
+// instantiated, and a dictionary carries data but no identity.
+func TestRecords(t *testing.T) {
+	const decl = `record Point
+  x: Int
+  y: Int
+end
+`
+	tests := []struct{ src, want string }{
+		// A record's fields are a parameter list, so construction is a call.
+		{decl + `println(Point(1, 2))`, "Point(x: 1, y: 2)"},
+		{decl + `println(Point(1, 2).x)`, "1"},
+		// Identity is the point.
+		{decl + `println(typeof(Point(1, 2)))`, "Point"},
+		{decl + `println(Point(1, 2) is Point)`, "true"},
+		{decl + `println(Point(1, 2) is Dictionary)`, "false"},
+		{decl + `println(Point(1, 2) is Any)`, "true"},
+		{decl + `println(Point(1, 2) == Point(1, 2))`, "true"},
+		{decl + `println(Point(1, 2) == Point(1, 3))`, "false"},
+		{decl + `println(typeof(Point))`, "Record"},
+		// Same fields, different type.
+		{decl + `record Size
+  x: Int
+  y: Int
+end
+println(Point(1, 2) == Size(1, 2))`, "false"},
+		// A hint names a record like any other type, and a case matches it.
+		{decl + `let f = func (p: Point) -> Int do p.x end
+println(f(Point(7, 0)))`, "7"},
+		{decl + `println(switch Point(1, 2) do case is Point then "yes" default then "no" end)`, "yes"},
+		{decl + `println(switch [:x => 1] do case is Point then "yes" default then "no" end)`, "no"},
+		// Defaults fill in omitted trailing fields.
+		{`record Config
+  host: String
+  port: Int = 8080
+end
+println(Config("localhost"))`, `Config(host: "localhost", port: 8080)`},
+		// An unhinted field takes anything.
+		{`record Box
+  contents
+end
+println(Box([1, 2]))`, "Box(contents: [1, 2])"},
+	}
+	for _, test := range tests {
+		if got := withStdlib(t, test.src); got != test.want {
+			t.Errorf("%s: got %q, want %q", test.src, got, test.want)
+		}
+	}
+
+	fails(t, decl+`println(Point(1))`, "expects at least 2 field(s), got 1")
+	fails(t, decl+`println(Point(1, 2, 3))`, "expects at most 2 field(s), got 3")
+	fails(t, decl+`println(Point(1, "two"))`, "field 'y' expects Int, got String")
+	fails(t, decl+`println(Point(1, 2).nope)`, "Point has no field 'nope'")
+	fails(t, decl+decl, "record 'Point' is already declared")
+	fails(t, `record Point
+  x: Int
+  x: Int
+end`, "declares 'x' twice")
+}
+
+// Records are immutable like everything else, so a field write rebinds the name
+// — the reading `a[0] = v` already had under the frozen-collections rule.
+func TestRecordUpdateReturnsNew(t *testing.T) {
+	if got := output(t, `record Point
+  x: Int
+  y: Int
+end
+var p = Point(1, 2)
+let before = p
+p.x = 5
+println(p)
+println(before)`); got != "Point(x: 5, y: 2)\nPoint(x: 1, y: 2)\n" {
+		t.Errorf("got %q", got)
+	}
+
+	// It nests, through records and dictionaries alike.
+	if got := output(t, `record Point
+  x: Int
+  y: Int
+end
+record Line
+  from: Point
+  to: Point
+end
+var l = Line(Point(0, 0), Point(1, 1))
+l.to.x = 9
+println(l)`); got != "Line(from: Point(x: 0, y: 0), to: Point(x: 9, y: 1))\n" {
+		t.Errorf("got %q", got)
+	}
+
+	if got := output(t, `var cfg = [:db => [:host => "old"]]
+cfg.db.host = "new"
+println(cfg)`); got != `[:db => [:host => "new"]]`+"\n" {
+		t.Errorf("got %q", got)
+	}
+
+	// A let-bound record cannot be written through, for the reason a let-bound
+	// array cannot.
+	fails(t, `record Point
+  x: Int
+end
+let p = Point(1)
+p.x = 2`, "cannot modify 'p'")
+
+	// And the reassignment type lock tells two records apart.
+	fails(t, `record Point
+  x: Int
+end
+record Size
+  x: Int
+end
+var v = Point(1)
+v = Size(1)`, "holds Point, so it cannot be assigned Size")
+}

--- a/internal/interp/records.go
+++ b/internal/interp/records.go
@@ -1,0 +1,111 @@
+package interp
+
+import (
+	"github.com/fadion/aria/internal/ast"
+	"github.com/fadion/aria/internal/source"
+	"github.com/fadion/aria/internal/value"
+)
+
+// RecordDef is a declared record, bound to its own name.
+//
+// Calling it constructs an instance, which is why a record needs no
+// construction syntax: its fields are a parameter list, so `Point(1, 2)` is an
+// ordinary call, with the same arity check, type hints and defaults every other
+// call has.
+//
+// Anything shaped like a domain object used to have no home. A module holds only
+// `let` and cannot be instantiated; a dictionary carries data but no identity, so
+// `typeof` said "Dictionary" for every one of them and `is` could not tell a
+// point from a config.
+type RecordDef struct {
+	Decl *ast.Record
+	Def  *value.RecordType
+	// File is where the declaration was written, so a fault building an
+	// instance is reported there.
+	File *source.File
+}
+
+func (*RecordDef) Type() value.Type       { return value.TRecord }
+func (d *RecordDef) String() string       { return "record " + d.Def.Name }
+func (d *RecordDef) Inspect() string      { return d.String() }
+func (d *RecordDef) FieldNames() []string { return d.Def.Fields }
+
+// evalRecord declares a record. The name is bound like a module's: a record is
+// an ordinary value that happens to be callable.
+func (i *Interp) evalRecord(n *ast.Record, e *env) value.Value {
+	if _, exists := i.records[n.Name.Value]; exists {
+		i.fail(n.Name.Span(), "record '%s' is already declared", n.Name.Value)
+	}
+
+	fields := make([]string, 0, len(n.Fields))
+	seen := map[string]bool{}
+	for _, f := range n.Fields {
+		if f == nil || f.Name == nil {
+			continue
+		}
+		if seen[f.Name.Value] {
+			i.fail(f.Name.Span(), "record '%s' declares '%s' twice", n.Name.Value, f.Name.Value)
+		}
+		seen[f.Name.Value] = true
+		fields = append(fields, f.Name.Value)
+	}
+
+	def := &RecordDef{
+		Decl: n,
+		Def:  &value.RecordType{Name: n.Name.Value, Fields: fields},
+		File: i.curFile(),
+	}
+	i.records[n.Name.Value] = def
+	e.define(n.Name.Value, def)
+	return def
+}
+
+// construct builds an instance from a call's arguments.
+//
+// The arity and type rules are a function's, because the fields are a parameter
+// list: a trailing field with a default may be omitted, and a hint is enforced.
+func (i *Interp) construct(def *RecordDef, args []value.Value, span source.Span) value.Value {
+	callerFile := i.curFile()
+	fields := def.Decl.Fields
+
+	required := 0
+	for idx, f := range fields {
+		if f.Default == nil {
+			required = idx + 1
+		}
+	}
+	if len(args) < required {
+		i.failIn(callerFile, span, "%s expects at least %d field(s), got %d",
+			def.Def.Name, required, len(args))
+	}
+	if len(args) > len(fields) {
+		i.failIn(callerFile, span, "%s expects at most %d field(s), got %d",
+			def.Def.Name, len(fields), len(args))
+	}
+
+	values := make([]value.Value, len(fields))
+	for idx, f := range fields {
+		if idx < len(args) {
+			values[idx] = args[idx]
+		} else {
+			// A default is evaluated in the file the record was declared in,
+			// which is where a fault in one belongs.
+			outer := i.file
+			i.file = def.File
+			values[idx] = i.eval(f.Default, i.globals)
+			i.file = outer
+		}
+		i.checkFieldType(def, f, values[idx], callerFile, span)
+	}
+	return value.NewRecord(def.Def, values)
+}
+
+func (i *Interp) checkFieldType(def *RecordDef, f *ast.FunctionParameter, v value.Value, file *source.File, span source.Span) {
+	if f.Type == nil || f.Type.Value == value.Any {
+		return
+	}
+	if value.TypeName(v) != f.Type.Value {
+		i.failIn(file, span, "%s field '%s' expects %s, got %s",
+			def.Def.Name, f.Name.Value, f.Type.Value, value.TypeName(v))
+	}
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -286,7 +286,7 @@ func startsConstruct(kind token.Kind) bool {
 	switch kind {
 	case token.Let, token.Var, token.Func, token.If, token.Switch, token.For,
 		token.While, token.Until, token.Try,
-		token.Module, token.Import, token.Return, token.Break, token.Continue,
+		token.Module, token.Record, token.Import, token.Return, token.Break, token.Continue,
 		token.Case, token.Default, token.End:
 		return true
 	}
@@ -403,6 +403,8 @@ func (p *Parser) parsePrefix() ast.Node {
 		return p.parseIf()
 	case token.Switch:
 		return p.parseSwitch()
+	case token.Record:
+		return p.parseRecord()
 	case token.Try:
 		return p.parseTry()
 	case token.While:
@@ -817,21 +819,29 @@ func (p *Parser) parseAssign(left ast.Node) ast.Node {
 	op := p.tok
 	operator := p.text(op)
 
-	switch target := left.(type) {
+	// Indexing and field access can nest, as in `a[0].x`, so walk down to the
+	// name being written through rather than checking one level. Under the
+	// frozen-collections rule every one of these is a rebinding of that name,
+	// which is what makes them the same shape.
+	switch left.(type) {
 	case *ast.Identifier:
-	case *ast.Subscript:
-		// Indexing can nest, as in a[0][1], so walk down to the name being
-		// written through rather than only checking one level.
-		base := ast.Node(target)
+	case *ast.Subscript, *ast.Access:
+		base := left
 		for {
-			sub, ok := base.(*ast.Subscript)
-			if !ok {
+			switch t := base.(type) {
+			case *ast.Subscript:
+				base = t.Left
+			case *ast.Access:
+				base = t.Left
+			default:
+				if _, ok := base.(*ast.Identifier); !ok {
+					return p.bad(left.Span(), "assignment expects a name on the left")
+				}
+				base = nil
+			}
+			if base == nil {
 				break
 			}
-			base = sub.Left
-		}
-		if _, ok := base.(*ast.Identifier); !ok {
-			return p.bad(left.Span(), "assignment expects a name on the left")
 		}
 	default:
 		return p.bad(left.Span(), "assignment expects a name on the left")
@@ -1458,6 +1468,77 @@ func (p *Parser) parseModule() ast.Node {
 		Name: name,
 		Body: body,
 	}
+}
+
+// parseRecord reads `record Name field... end`.
+//
+// A field is a name, an optional type hint and an optional default — the same
+// shape as a parameter, and read by the same code, because a record's
+// constructor is a call and its fields are that call's parameters.
+func (p *Parser) parseRecord() ast.Node {
+	start := p.tok.Span
+
+	if !p.expectPeek(token.Ident) {
+		return &ast.Bad{Base: ast.Base{Sp: start}, Text: "record"}
+	}
+	node := &ast.Record{
+		Base: ast.Base{Sp: start},
+		Name: &ast.Identifier{Base: ast.Base{Sp: p.tok.Span}, Value: p.text(p.tok)},
+	}
+
+	if p.atPeek(token.Do) {
+		p.advance()
+	}
+	p.advance()
+
+	for !p.at(token.End, token.EOF) {
+		if p.at(token.Newline, token.Comma) {
+			p.advance()
+			continue
+		}
+		if !p.at(token.Ident) {
+			return p.bad(p.tok.Span, "a record body takes field names, found %s", p.describe(p.tok))
+		}
+
+		field, ok := p.parseField()
+		if !ok {
+			return field
+		}
+		node.Fields = append(node.Fields, field.(*ast.FunctionParameter))
+		p.advance()
+	}
+
+	if !p.at(token.End) {
+		return p.bad(span(start, p.tok.Span), "missing 'end' to close 'record'")
+	}
+
+	node.Sp = span(start, p.tok.Span)
+	return node
+}
+
+// parseField reads one `name[: Type][= default]`. The cursor is on the name.
+func (p *Parser) parseField() (ast.Node, bool) {
+	field := &ast.FunctionParameter{
+		Base: ast.Base{Sp: p.tok.Span},
+		Name: &ast.Identifier{Base: ast.Base{Sp: p.tok.Span}, Value: p.text(p.tok)},
+	}
+
+	if p.atPeek(token.Colon) {
+		p.advance()
+		if !p.expectPeek(token.Ident) {
+			return &ast.Bad{Base: ast.Base{Sp: field.Sp}, Text: field.Name.Value}, false
+		}
+		field.Type = &ast.Identifier{Base: ast.Base{Sp: p.tok.Span}, Value: p.text(p.tok)}
+	}
+
+	if p.atPeek(token.Assign) {
+		p.advance()
+		p.advance()
+		field.Default = p.parseExpr(precAssign)
+	}
+
+	field.Sp = span(field.Sp, p.tok.Span)
+	return field, true
 }
 
 // parseFunction reads `func (params) [-> Type] body end`.

--- a/internal/resolver/corpus_test.go
+++ b/internal/resolver/corpus_test.go
@@ -118,6 +118,7 @@ var expectedResolveErrors = map[string]string{
 	"switch-capture-scope.ari":       "reads a capture outside its own arm",
 	"try-rescue-scope.ari":           "reads a rescued name outside its rescue",
 	"_undefined.ari":                 "is a fixture whose whole point is an undefined name",
+	"immutable-let.ari":              "writes a field through a let-bound record",
 }
 
 // Three cases that USED to fail now resolve cleanly, which is the point:

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -167,6 +167,11 @@ type Resolver struct {
 	// this file.
 	moduleMembers map[*Binding][]string
 
+	// records holds the record types declared anywhere in the compilation, so
+	// `is Point` and `p: Point` name something this pass can check. Records are
+	// hoisted, like modules.
+	records map[string][]string
+
 	// loops and funcs count the enclosing loop and function bodies, so that
 	// break, continue and return can be checked where they mean something. A
 	// function body resets loops: a `break` inside a function nested in a loop
@@ -188,6 +193,7 @@ func New(file *source.File, diags *diag.Bag) *Resolver {
 		modules:       map[string]bool{},
 		hoisted:       map[*Binding]bool{},
 		moduleMembers: map[*Binding][]string{},
+		records:       map[string][]string{},
 	}
 	r.current = newScope(nil)
 	for _, name := range Builtins {
@@ -293,6 +299,26 @@ func (r *Resolver) unit(prog *ast.Program) {
 func (r *Resolver) collectModules(nodes []ast.Node) {
 	for _, n := range nodes {
 		switch n := n.(type) {
+		case *ast.Record:
+			// A record is hoisted like a module: its name is a type, and a type
+			// that only exists after its declaration would make the order of two
+			// declarations matter for no reason.
+			if n.Name == nil || r.records[n.Name.Value] != nil {
+				continue
+			}
+			fields := []string{}
+			for _, f := range n.Fields {
+				if f != nil && f.Name != nil {
+					fields = append(fields, f.Name.Value)
+				}
+			}
+			r.records[n.Name.Value] = fields
+			b := r.declare(n.Name, KindLet, false)
+			if b != nil {
+				// The constructor is reachable by name, and `Point.x` is not a
+				// thing, so the definition has no members to access.
+				r.moduleMembers[b] = nil
+			}
 		case *ast.Module:
 			// A second `module M` is left undeclared on purpose: the evaluator
 			// reports the redeclaration, with the module's own message.
@@ -572,6 +598,25 @@ func (r *Resolver) node(n ast.Node) {
 
 	case *ast.Module:
 		r.module(n)
+	case *ast.Record:
+		// The name is declared by collectModules; the field hints and defaults
+		// are what is left to check, exactly as for a function's parameters.
+		for _, f := range n.Fields {
+			if f == nil {
+				continue
+			}
+			r.typeName(f.Type)
+			if f.Default == nil {
+				continue
+			}
+			r.node(f.Default)
+			if f.Type != nil && f.Type.Value != value.Any {
+				if got := literalType(f.Default); got != "" && got != f.Type.Value {
+					r.diags.Errorf(f.Default.Span(), "field '%s' is declared %s but defaults to %s",
+						f.Name.Value, f.Type.Value, got)
+				}
+			}
+		}
 	case *ast.Access:
 		// The left side is an ordinary expression. resolveName already lets a
 		// bare module name through, so `Enum.size` resolves without `.` having
@@ -731,17 +776,24 @@ func (r *Resolver) assign(n *ast.Assign) {
 	target := n.Name
 	subscript := false
 	for {
-		sub, ok := target.(*ast.Subscript)
-		if !ok {
-			break
+		switch t := target.(type) {
+		case *ast.Subscript:
+			subscript = true
+			// `a[] = v` and `a[_] = v` both parse to a placeholder index. On
+			// the left of an assignment that is the append target, not a stray
+			// `_`.
+			if _, appendTarget := t.Index.(*ast.Placeholder); !appendTarget {
+				r.node(t.Index)
+			}
+			target = t.Left
+			continue
+		case *ast.Access:
+			// `p.x = v` rebinds p, the same way `a[0] = v` rebinds a.
+			subscript = true
+			target = t.Left
+			continue
 		}
-		subscript = true
-		// `a[] = v` and `a[_] = v` both parse to a placeholder index. On the
-		// left of an assignment that is the append target, not a stray `_`.
-		if _, appendTarget := sub.Index.(*ast.Placeholder); !appendTarget {
-			r.node(sub.Index)
-		}
-		target = sub.Left
+		break
 	}
 
 	id, ok := target.(*ast.Identifier)
@@ -899,6 +951,9 @@ func (r *Resolver) typeName(id *ast.Identifier) {
 	if id == nil || value.IsTypeName(id.Value) {
 		return
 	}
+	if _, isRecord := r.records[id.Value]; isRecord {
+		return
+	}
 	// One diagnostic rather than an error and a note: a note with the same span
 	// would draw the same line and caret underneath itself.
 	r.diags.Errorf(id.Span(), "'%s' is not a type: expected one of %s",
@@ -923,7 +978,7 @@ func (r *Resolver) moduleMember(n *ast.Access) {
 		return // undefined, or hidden behind an import; already handled
 	}
 	members, known := r.moduleMembers[ref.Binding]
-	if !known {
+	if !known || members == nil {
 		return // not a module, or one whose members this pass cannot see
 	}
 	for _, m := range members {

--- a/internal/token/token.go
+++ b/internal/token/token.go
@@ -109,6 +109,7 @@ const (
 	Try
 	Rescue
 	Module
+	Record
 	Import
 )
 
@@ -200,6 +201,7 @@ var names = [...]string{
 	Try:      "try",
 	Rescue:   "rescue",
 	Module:   "module",
+	Record:   "record",
 	Import:   "import",
 }
 
@@ -240,6 +242,7 @@ var keywords = map[string]Kind{
 	"try":      Try,
 	"rescue":   Rescue,
 	"module":   Module,
+	"record":   Record,
 	"import":   Import,
 	// true, false and nil are keywords lexically, but carry a literal's kind
 	// so the parser treats them as the values they are.

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -41,6 +41,7 @@ const (
 	TDict
 	TFunc
 	TModule
+	TRecord
 )
 
 func (t Type) String() string {
@@ -63,6 +64,8 @@ func (t Type) String() string {
 		return "Function"
 	case TModule:
 		return "Module"
+	case TRecord:
+		return "Record"
 	}
 	return "Nil"
 }
@@ -72,21 +75,23 @@ func (t Type) String() string {
 // yet annotated" and `: Any` means "anything, deliberately".
 const Any = "Any"
 
-// TypeNames are the names a type annotation, `is` or `as` may use.
+// TypeNames are the built-in names a type annotation, `is` or `as` may use. A
+// declared record adds its own, which the resolver knows about and this package
+// does not.
 func TypeNames() []string {
-	names := make([]string, 0, int(TModule)+2)
-	for t := TNil; t <= TModule; t++ {
+	names := make([]string, 0, int(TRecord)+2)
+	for t := TNil; t <= TRecord; t++ {
 		names = append(names, t.String())
 	}
 	return append(names, Any)
 }
 
-// IsTypeName reports whether s names a type an annotation may use.
+// IsTypeName reports whether s names a built-in type.
 func IsTypeName(s string) bool {
 	if s == Any {
 		return true
 	}
-	for t := TNil; t <= TModule; t++ {
+	for t := TNil; t <= TRecord; t++ {
 		if t.String() == s {
 			return true
 		}
@@ -443,6 +448,20 @@ func Equal(a, b Value) bool {
 		case String:
 			return string(a) == string(b)
 		}
+	case *Record:
+		// Same declaration and equal fields. Two records of different types are
+		// never equal, however their fields line up — that is what having a
+		// type identity is for.
+		bb, ok := b.(*Record)
+		if !ok || a.Def != bb.Def {
+			return false
+		}
+		for i := range a.values {
+			if !Equal(a.values[i], bb.values[i]) {
+				return false
+			}
+		}
+		return true
 	case *Array:
 		bb, ok := b.(*Array)
 		if !ok || a.Len() != bb.Len() {
@@ -504,4 +523,89 @@ func SortedKeys(d *Dict) []Value {
 		return keys[i].Inspect() < keys[j].Inspect()
 	})
 	return keys
+}
+
+// ---------------------------------------------------------------------------
+// Records
+// ---------------------------------------------------------------------------
+
+// A RecordType is a declared record: a name and a fixed list of field names.
+// One of these is shared by every instance, so identity is pointer equality and
+// a field lookup is a small scan rather than a hash.
+type RecordType struct {
+	Name   string
+	Fields []string
+}
+
+// Index returns where a field sits, or -1.
+func (t *RecordType) Index(name string) int {
+	for i, f := range t.Fields {
+		if f == name {
+			return i
+		}
+	}
+	return -1
+}
+
+// Record is an instance. Fields are positional, in declaration order, because
+// the shape is fixed at declaration and a map would cost a hash per access to
+// store what the type already knows.
+//
+// Immutable like every other collection: With returns a new record.
+type Record struct {
+	Def    *RecordType
+	values []Value
+}
+
+// NewRecord takes ownership of values, which must match the type's field count.
+func NewRecord(def *RecordType, values []Value) *Record {
+	return &Record{Def: def, values: values}
+}
+
+func (*Record) Type() Type { return TRecord }
+
+func (r *Record) String() string {
+	parts := make([]string, 0, len(r.values))
+	for i, f := range r.Def.Fields {
+		parts = append(parts, f+": "+r.values[i].Inspect())
+	}
+	return r.Def.Name + "(" + strings.Join(parts, ", ") + ")"
+}
+
+func (r *Record) Inspect() string { return r.String() }
+
+// Values returns the fields in declaration order, for reading.
+func (r *Record) Values() []Value { return r.values }
+
+func (r *Record) Get(name string) (Value, bool) {
+	at := r.Def.Index(name)
+	if at < 0 {
+		return nil, false
+	}
+	return r.values[at], true
+}
+
+// With returns a new record with one field replaced. The receiver is untouched,
+// for the reason every other collection copies: an update that wrote in place
+// could change a value computed earlier.
+func (r *Record) With(name string, v Value) (*Record, bool) {
+	at := r.Def.Index(name)
+	if at < 0 {
+		return nil, false
+	}
+	out := make([]Value, len(r.values))
+	copy(out, r.values)
+	out[at] = v
+	return &Record{Def: r.Def, values: out}, true
+}
+
+// TypeName is what `typeof` reports and what `is` tests against.
+//
+// A record answers its own name rather than "Record", which is the whole point
+// of the feature: without it a record is a dictionary with extra steps.
+func TypeName(v Value) string {
+	if r, ok := v.(*Record); ok {
+		return r.Def.Name
+	}
+	return v.Type().String()
 }

--- a/testdata/semantics/errors/switch-unknown-type-case.out
+++ b/testdata/semantics/errors/switch-unknown-type-case.out
@@ -1,4 +1,4 @@
-switch-unknown-type-case.ari:3:11: error: 'Banana' is not a type: expected one of Nil, Bool, Int, Float, String, Atom, Array, Dictionary, Function, Module, Any
+switch-unknown-type-case.ari:3:11: error: 'Banana' is not a type: expected one of Nil, Bool, Int, Float, String, Atom, Array, Dictionary, Function, Module, Record, Any
     case is Banana then "never"
             ^^^^^^
 --- exit: 1

--- a/testdata/semantics/errors/unknown-parameter-type.out
+++ b/testdata/semantics/errors/unknown-parameter-type.out
@@ -1,7 +1,7 @@
-unknown-parameter-type.ari:3:18: error: 'Banana' is not a type: expected one of Nil, Bool, Int, Float, String, Atom, Array, Dictionary, Function, Module, Any
+unknown-parameter-type.ari:3:18: error: 'Banana' is not a type: expected one of Nil, Bool, Int, Float, String, Atom, Array, Dictionary, Function, Module, Record, Any
   let f = func (n: Banana) -> Fruit do n end
                    ^^^^^^
-unknown-parameter-type.ari:3:29: error: 'Fruit' is not a type: expected one of Nil, Bool, Int, Float, String, Atom, Array, Dictionary, Function, Module, Any
+unknown-parameter-type.ari:3:29: error: 'Fruit' is not a type: expected one of Nil, Bool, Int, Float, String, Atom, Array, Dictionary, Function, Module, Record, Any
   let f = func (n: Banana) -> Fruit do n end
                               ^^^^^
 --- exit: 1

--- a/testdata/semantics/operators/as-unknown-type.out
+++ b/testdata/semantics/operators/as-unknown-type.out
@@ -1,4 +1,4 @@
-as-unknown-type.ari:2:14: error: 'Banana' is not a type: expected one of Nil, Bool, Int, Float, String, Atom, Array, Dictionary, Function, Module, Any
+as-unknown-type.ari:2:14: error: 'Banana' is not a type: expected one of Nil, Bool, Int, Float, String, Atom, Array, Dictionary, Function, Module, Record, Any
   println(5 as Banana)
                ^^^^^^
 --- exit: 1

--- a/testdata/semantics/operators/is-unknown-type.out
+++ b/testdata/semantics/operators/is-unknown-type.out
@@ -1,4 +1,4 @@
-is-unknown-type.ari:5:14: error: 'Banana' is not a type: expected one of Nil, Bool, Int, Float, String, Atom, Array, Dictionary, Function, Module, Any
+is-unknown-type.ari:5:14: error: 'Banana' is not a type: expected one of Nil, Bool, Int, Float, String, Atom, Array, Dictionary, Function, Module, Record, Any
   println(5 is Banana)
                ^^^^^^
 --- exit: 1

--- a/testdata/semantics/records/arity.ari
+++ b/testdata/semantics/records/arity.ari
@@ -1,0 +1,5 @@
+record Point
+  x: Int
+  y: Int
+end
+println(Point(1))

--- a/testdata/semantics/records/arity.out
+++ b/testdata/semantics/records/arity.out
@@ -1,0 +1,4 @@
+arity.ari:5:9: error: Point expects at least 2 field(s), got 1
+  println(Point(1))
+          ^^^^^^^^
+--- exit: 1

--- a/testdata/semantics/records/declare-and-construct.ari
+++ b/testdata/semantics/records/declare-and-construct.ari
@@ -1,0 +1,32 @@
+// Anything shaped like a domain object had no home. A module holds only `let`
+// and cannot be instantiated; a dictionary carries data but no identity, so
+// typeof said "Dictionary" for every one of them.
+record Point
+  x: Int
+  y: Int
+end
+
+let p = Point(1, 2)
+println(p)
+println(p.x)
+println(p.y)
+
+// A record's fields are a parameter list, so constructing one is an ordinary
+// call: the same arity check, the same type hints, the same defaults. That is
+// why a record needs no construction syntax of its own.
+record Config
+  host: String
+  port: Int = 8080
+  debug: Bool = false
+end
+println(Config("localhost"))
+println(Config("localhost", 9000))
+println(Config("localhost", 9000, true))
+
+// A field with no hint takes anything.
+record Box
+  contents
+end
+println(Box(1))
+println(Box("anything"))
+println(Box([1, 2]))

--- a/testdata/semantics/records/declare-and-construct.out
+++ b/testdata/semantics/records/declare-and-construct.out
@@ -1,0 +1,10 @@
+Point(x: 1, y: 2)
+1
+2
+Config(host: "localhost", port: 8080, debug: false)
+Config(host: "localhost", port: 9000, debug: false)
+Config(host: "localhost", port: 9000, debug: true)
+Box(contents: 1)
+Box(contents: "anything")
+Box(contents: [1, 2])
+--- exit: 0

--- a/testdata/semantics/records/errors.ari
+++ b/testdata/semantics/records/errors.ari
@@ -1,0 +1,5 @@
+record Point
+  x: Int
+  y: Int
+end
+println(Point(1, 2).nope)

--- a/testdata/semantics/records/errors.out
+++ b/testdata/semantics/records/errors.out
@@ -1,0 +1,4 @@
+errors.ari:5:21: error: Point has no field 'nope'
+  println(Point(1, 2).nope)
+                      ^^^^
+--- exit: 1

--- a/testdata/semantics/records/field-type.ari
+++ b/testdata/semantics/records/field-type.ari
@@ -1,0 +1,5 @@
+record Point
+  x: Int
+  y: Int
+end
+println(Point(1, "two"))

--- a/testdata/semantics/records/field-type.out
+++ b/testdata/semantics/records/field-type.out
@@ -1,0 +1,4 @@
+field-type.ari:5:9: error: Point field 'y' expects Int, got String
+  println(Point(1, "two"))
+          ^^^^^^^^^^^^^^^
+--- exit: 1

--- a/testdata/semantics/records/identity.ari
+++ b/testdata/semantics/records/identity.ari
@@ -1,0 +1,44 @@
+// The point of the feature: without an identity a record is a dictionary with
+// extra steps.
+record Point
+  x: Int
+  y: Int
+end
+record Size
+  x: Int
+  y: Int
+end
+
+let p = Point(1, 2)
+println(typeof(p))
+println(p is Point)
+println(p is Size)
+println(p is Dictionary)
+println(p is Any)
+
+// Two records with the same field values are still different types.
+println(Point(1, 2) == Point(1, 2))
+println(Point(1, 2) == Point(1, 3))
+println(Point(1, 2) == Size(1, 2))
+
+// A record name is a value, and the declaration itself is a Record.
+println(typeof(Point))
+println(Point)
+
+// A hint names a record like any other type.
+let distance = func (a: Point, b: Point) -> Int
+  Math.abs(a.x - b.x) + Math.abs(a.y - b.y)
+end
+println(distance(Point(0, 0), Point(3, 4)))
+
+// And a switch matches on it.
+let describe = func (v) do
+  switch v
+  case is Point then "a point"
+  case is Size then "a size"
+  case is Any then "something else"
+  end
+end
+println(describe(Point(1, 2)))
+println(describe(Size(1, 2)))
+println(describe([:x => 1]))

--- a/testdata/semantics/records/identity.out
+++ b/testdata/semantics/records/identity.out
@@ -1,0 +1,15 @@
+Point
+true
+false
+false
+true
+true
+false
+false
+Record
+record Point
+7
+a point
+a size
+something else
+--- exit: 0

--- a/testdata/semantics/records/immutable-let.ari
+++ b/testdata/semantics/records/immutable-let.ari
@@ -1,0 +1,8 @@
+// A record bound with `let` cannot be rebound, and a field write IS a rebinding
+// — the same reading `a[0] = v` already had for a collection.
+record Point
+  x: Int
+  y: Int
+end
+let fixed = Point(1, 2)
+fixed.x = 3

--- a/testdata/semantics/records/immutable-let.out
+++ b/testdata/semantics/records/immutable-let.out
@@ -1,0 +1,7 @@
+immutable-let.ari:8:1: error: cannot modify 'fixed': it is bound with let, which cannot be rebound
+  fixed.x = 3
+  ^^^^^
+immutable-let.ari:7:5: note: 'fixed' is declared here
+  let fixed = Point(1, 2)
+      ^^^^^
+--- exit: 1

--- a/testdata/semantics/records/update-returns-new.ari
+++ b/testdata/semantics/records/update-returns-new.ari
@@ -1,0 +1,29 @@
+// Records are immutable like everything else, so `p.x = 5` rebinds p to a new
+// record — the same reading `a[0] = v` already had for a collection.
+record Point
+  x: Int
+  y: Int
+end
+
+var p = Point(1, 2)
+let original = p
+p.x = 5
+println(p)
+println(original)
+
+// It nests, through records and dictionaries alike.
+record Line
+  from: Point
+  to: Point
+end
+var l = Line(Point(0, 0), Point(1, 1))
+l.to.x = 9
+println(l)
+
+var cfg = [:db => [:host => "old"]]
+cfg.db.host = "new"
+println(cfg)
+
+var points = [Point(1, 1), Point(2, 2)]
+points[0].x = 7
+println(points)

--- a/testdata/semantics/records/update-returns-new.out
+++ b/testdata/semantics/records/update-returns-new.out
@@ -1,0 +1,6 @@
+Point(x: 5, y: 2)
+Point(x: 1, y: 2)
+Line(from: Point(x: 0, y: 0), to: Point(x: 9, y: 1))
+[:db => [:host => "new"]]
+[Point(x: 7, y: 1), Point(x: 2, y: 2)]
+--- exit: 0


### PR DESCRIPTION
Anything shaped like a domain object had none. A module holds only `let` and cannot be instantiated — the README says so in as many words — and a dictionary carries data but no identity, so `typeof` reported `Dictionary` for every one of them and `is` could not tell a point from a config.

The issue suggested deferring this until #13, #14 and #17 had settled the surrounding grammar. They have, so this is the real thing rather than the convention route.

## The design

**A record's fields are a parameter list.** Fields reuse `ast.FunctionParameter` — a name, an optional hint, an optional default, nothing new — and constructing one is an ordinary call: `Point(1, 2)`, with the same arity check, type enforcement and defaults. No construction syntax, no field syntax.

*Named construction is deliberately absent*: `Point(x: 1, y: 2)` is a change to every call in the language, not a record feature, and worth making once for all calls.

**Identity is the point.** `typeof` answers the record's own name and `is` tests against it. Two records with the same field values are still different types. `value.TypeName` is the one place that answers this, and everything comparing a type name goes through it — including the reassignment type lock, which without it would let a `Point` be assigned to a var holding a `Size`, since both are `TRecord`.

**Update returns a new record.** `p.x = 5` rebinds `p`, the reading `a[0] = v` already had under the frozen-collections rule — so a `let`-bound record cannot be written through, for the reason a `let`-bound array cannot. The assignment target walk now handles field links as well as subscripts, to any depth, which also makes `d.key = v` work on a dictionary where it did not before.

**Records are hoisted like modules**, and the resolver knows their names, so `is Point` and `p: Point` are checked like any other type.

**Destructuring a record by field is deliberately not here**: it needs the same spelling dictionary destructuring needs — binding by name rather than by position — and both are worth deciding together. Field access plus `case is Point` covers matching meanwhile.

Seven cases added, plus Go tests. Four goldens changed, all the same change: "Record" joins the list of type names a diagnostic offers.

Closes #23