### PR TITLE
ci: skip the matrix for files nothing in it reads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,22 @@ name: CI
 on:
   # Only master on push. A branch with a PR open is covered by pull_request,
   # and listening for both ran every one of them twice.
+  #
+  # paths-ignore lists the files nothing here reads. README.md is deliberately
+  # not among them: the language job runs every one of its code blocks through
+  # the interpreter, so it is executable and a change to it can fail CI.
+  # Anchors would say this once, but Actions does not expand them.
   push:
     branches: [master]
+    paths-ignore:
+      - 'docs/**'
+      - 'CLAUDE.md'
+      - 'LICENSE'
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'CLAUDE.md'
+      - 'LICENSE'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Every pull request runs six jobs across three platforms, and a change to `docs/architecture.md` or `CLAUDE.md` pays for all of it to learn nothing. `README.md` stays on full CI on purpose: the `language` job runs its code blocks through the interpreter, so it is executable and a change to it can fail.

## What changed

- Added `paths-ignore` to the `push` and `pull_request` triggers, covering `docs/**`, `CLAUDE.md` and `LICENSE`.
- Noted in a comment why `README.md` is not on the list, and why the list is written out twice rather than shared through a YAML anchor.
