### PR TITLE
feat: reject an empty body, keep an empty container

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ In the same style, an index can be used to check if it exists. It will return `n
 ```swift
 if names[10]
   // handle it
+  nil
 end
 ```
 
@@ -436,6 +437,7 @@ To check for a key's existence, you can access it as normal and check if it's `n
 ```swift
 if user["location"] == nil
   // do smth
+  nil
 end
 ```
 
@@ -930,6 +932,17 @@ end
 println(area) // 42
 ```
 
+A body has to hold something. An empty `if`, `else`, `for`, `while`, `until`, `func`, `do`, `try`, `rescue` or `switch` arm is an error, because a block that runs nothing is almost always an unfinished edit rather than an intention. Comments don't count, so a body holding only a `// todo` is empty as far as the parser is concerned:
+
+```swift
+let stub = func x
+  // work this out later
+  nil
+end
+```
+
+Writing `nil` is how you say "deliberately nothing", and it says it where a reader will notice. A `module` and a `record` are containers rather than bodies, so an empty one of those is fine.
+
 ## Conditionals
 
 Aria provides two types of conditional statements. The `if/else` is limited to just an `if` and/or `else` block, without support for multiple `else if` blocks. That's because it advocates the use of the much better looking and flexible `switch` statement.
@@ -1285,6 +1298,7 @@ module Color
   let grey = "#666"
   let hexToRGB = func hex
     // some calculations
+    nil
   end
 end
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -739,6 +739,47 @@ that a call fails as an ordinary Aria error. Without it, runaway recursion grew 
 goroutine stack to Go's 1 GB ceiling and killed the process with a traceback, which is not
 something the author of an Aria program can act on.
 
+## An empty body is a mistake; an empty container is not
+
+The original rejected an empty body in four places, each with its own check: `if`, the
+`else` half of one, `for` and `func`. The rewrite accepted them everywhere, not as a
+decision but as a consequence of blocks becoming ordinary node lists — there was no longer
+anywhere the emptiness was noticed. `while`, `until`, `do`, `try` and `switch` arms arrived
+later and inherited the permissive reading by default.
+
+A body with nothing in it runs nothing. It is an unfinished edit or a stub, and in either
+case the program says one thing and means another. For a `for` it is worse than dead code:
+the loop collects a value per iteration, so `for i in 1..1000000 end` quietly builds a
+million-element array of nils. That is the silent-plausible-result failure this codebase
+legislates against elsewhere, and `while` already exists for the case where the array is
+not wanted, so the error has an obvious fix to point at.
+
+So every block holding code to run rejects an empty one: `if`, `else`, `for`, `while`,
+`until`, `func`, `do`, `try`, `rescue`, and a `switch` arm or `default`. Writing `nil` says
+"deliberately nothing" in one more word, and says it where a reader will see it.
+
+A `module` and a `record` are containers rather than bodies, and keep taking an empty one.
+`module M end` names a namespace not filled in yet and `record R end` is a unit type whose
+instances are all equal — both name something that exists, which an empty body does not.
+
+**A comment-only body counts as empty.** Comments are not nodes, so `if x` with nothing but
+`// handle it` in it has an empty block and is rejected. This is the rule's most visible
+consequence: it caught three of the README's own placeholder examples. The alternative
+would be tracking comment spans per block so the parser could tell "no code" from "nothing
+at all", which is machinery for a distinction that helps nobody — `nil` is checkable and a
+comment is not.
+
+The check lives in the parser, at each construct's own call to `codeBlock`, so the message
+names the construct. It reports to the bag directly rather than through `errorAt`, which
+would set `panicking`. That flag suppresses the cascade from a parser that has lost its
+place, and this one has not: it knows exactly where it is and carries on correctly, so a
+second empty body further down is a separate mistake and is reported too.
+
+Nothing is reported at end of input. A half-typed `if true` in the REPL has an empty block
+for the same reason it has no `end` yet, and turning "keep typing" into an error would
+break the one thing the incomplete-input signal exists for. The missing-`end` diagnostic is
+the one that belongs there.
+
 ## The characterization suite
 
 `testdata/semantics/` holds 219 cases. Each `.ari` file has a `.out` golden recording
@@ -885,6 +926,3 @@ go test ./internal/parser/  -run=Fuzz -fuzz=FuzzParse -fuzztime=30s
 - **Slot-based scopes.** The resolver computes slot indices and scope sizes that the
   evaluator ignores, walking a chain of name maps instead. Switching would make lookup an
   array index.
-- **Empty bodies.** `if`/`for`/`func` with an empty body are accepted and evaluate to
-  `nil`. The original rejected them. Nothing decided this either way; it fell out of
-  blocks being ordinary node lists.

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -1228,13 +1228,13 @@ func (p *Parser) parseIf() ast.Node {
 		p.advance()
 	}
 
-	then := p.parseBlock(token.Else, token.End)
+	then := p.codeBlock("if", token.Else, token.End)
 
 	node := &ast.If{Base: ast.Base{Sp: start}, Condition: cond, Then: then}
 
 	if p.at(token.Else) {
 		p.advance()
-		node.Else = p.parseBlock(token.End)
+		node.Else = p.codeBlock("else", token.End)
 	}
 
 	if !p.at(token.End) {
@@ -1277,6 +1277,34 @@ func (p *Parser) parseBlock(terminators ...token.Kind) *ast.Block {
 	return block
 }
 
+// codeBlock reads a block that holds code to run, and reports an empty one.
+//
+// A body with nothing in it runs nothing and is an unfinished edit rather than
+// an intention. For a `for` it is worse than dead code: the loop collects a
+// value per iteration, so `for i in 1..1000000 end` quietly builds a
+// million-element array of nils. Writing `nil` says "deliberately nothing" in
+// one more word.
+//
+// `module` and `record` keep using parseBlock directly. They are containers
+// rather than bodies, and an empty one still names something that exists.
+//
+// The diagnostic goes to the bag rather than through errorAt, which would set
+// panicking. That flag exists to suppress the cascade from a confused parser,
+// and this parser is not confused: it knows exactly where it is and carries on
+// correctly, so every later diagnostic in the file should still be reported,
+// including a second empty body.
+//
+// Nothing is reported at end of input. A half-typed `if true` in the REPL has
+// an empty block for the same reason it has no `end` yet, and the caller's
+// missing-'end' error is the one that belongs there.
+func (p *Parser) codeBlock(what string, terminators ...token.Kind) *ast.Block {
+	block := p.parseBlock(terminators...)
+	if len(block.Nodes) == 0 && !p.at(token.EOF) {
+		p.diags.Errorf(block.Sp, "empty %s body; write nil if it is meant to do nothing", what)
+	}
+	return block
+}
+
 // markDiscarded flags every `for` in nodes but the last as producing a value
 // nobody reads, so the evaluator can skip collecting one.
 //
@@ -1301,7 +1329,7 @@ func (p *Parser) parseBlockExpression() ast.Node {
 	start := p.tok.Span
 	p.advance()
 
-	block := p.parseBlock(token.End)
+	block := p.codeBlock("do", token.End)
 	if !p.at(token.End) {
 		return p.bad(span(start, p.tok.Span), "missing 'end' to close 'do'")
 	}
@@ -1337,7 +1365,7 @@ func (p *Parser) parseTry() ast.Node {
 		p.advance()
 	}
 
-	node.Body = p.parseBlock(token.Rescue, token.End)
+	node.Body = p.codeBlock("try", token.Rescue, token.End)
 	if !p.at(token.Rescue) {
 		return p.bad(span(start, p.tok.Span), "missing 'rescue' in 'try'")
 	}
@@ -1349,7 +1377,7 @@ func (p *Parser) parseTry() ast.Node {
 	}
 
 	p.advance()
-	node.Rescue = p.parseBlock(token.End)
+	node.Rescue = p.codeBlock("rescue", token.End)
 	if !p.at(token.End) {
 		return p.bad(span(start, p.tok.Span), "missing 'end' to close 'try'")
 	}
@@ -1372,7 +1400,7 @@ func (p *Parser) parseWhile(until bool) ast.Node {
 		p.advance()
 	}
 
-	node.Body = p.parseBlock(token.End)
+	node.Body = p.codeBlock(keywordOf(until), token.End)
 	if !p.at(token.End) {
 		return p.bad(span(start, p.tok.Span), "missing 'end' to close '%s'", keywordOf(until))
 	}
@@ -1430,7 +1458,7 @@ func (p *Parser) parseFor() ast.Node {
 		p.advance()
 	}
 
-	node.Body = p.parseBlock(token.End)
+	node.Body = p.codeBlock("for", token.End)
 
 	if !p.at(token.End) {
 		return p.bad(span(start, p.tok.Span), "missing 'end' to close 'for'")
@@ -1611,7 +1639,7 @@ func (p *Parser) parseFunction() ast.Node {
 		p.advance()
 	}
 
-	node.Body = p.parseBlock(token.End)
+	node.Body = p.codeBlock("func", token.End)
 
 	if !p.at(token.End) {
 		return p.bad(span(start, p.tok.Span), "missing 'end' to close 'func'")
@@ -1769,7 +1797,7 @@ func (p *Parser) parseSwitch() ast.Node {
 			if p.at(token.Then) {
 				p.advance()
 			}
-			c.Body = p.parseBlock(token.Case, token.Default, token.End)
+			c.Body = p.codeBlock("case", token.Case, token.Default, token.End)
 			c.Sp = span(c.Sp, p.tok.Span)
 			node.Cases = append(node.Cases, c)
 			continue
@@ -1779,7 +1807,7 @@ func (p *Parser) parseSwitch() ast.Node {
 			if p.at(token.Then) {
 				p.advance()
 			}
-			node.Default = p.parseBlock(token.Case, token.Default, token.End)
+			node.Default = p.codeBlock("default", token.Case, token.Default, token.End)
 			continue
 
 		case token.Newline:

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -400,3 +400,73 @@ func TestNodesHaveValidSpans(t *testing.T) {
 		return true
 	})
 }
+
+// An empty code block is an unfinished edit, not an intention. The original
+// rejected one in `if`, `else`, `for` and `func`; the rewrite accepted it
+// everywhere because blocks became ordinary node lists. This pins the rule down
+// across every construct, including the ones the original never had.
+//
+// `for` is the reason the rule is worth having at all: the loop collects a value
+// per iteration, so `for i in 1..1000000 end` quietly builds a million-element
+// array of nils.
+func TestEmptyCodeBodiesAreRejected(t *testing.T) {
+	for _, tt := range []struct{ name, src string }{
+		{"if", "if true\nend"},
+		{"else", "if true\n  nil\nelse\nend"},
+		{"for", "for i in 1..3\nend"},
+		{"while", "while false\nend"},
+		{"until", "until true\nend"},
+		{"func", "let f = func ()\nend"},
+		{"do", "let v = do\nend"},
+		{"try", "try\nrescue\n  nil\nend"},
+		{"rescue", "try\n  nil\nrescue\nend"},
+		{"case", "switch 1\ncase 1\ndefault\n  nil\nend"},
+		{"default", "switch 1\ncase 1\n  nil\ndefault\nend"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, bag := parse(t, tt.src)
+			if !bag.HasErrors() {
+				t.Fatalf("%q: expected a diagnostic for the empty %s body", tt.src, tt.name)
+			}
+			if got := bag.Render(); !strings.Contains(got, "empty "+tt.name+" body") {
+				t.Errorf("%q: diagnostic does not name the construct:\n%s", tt.src, got)
+			}
+		})
+	}
+}
+
+// A module or a record is a container, not a body. An empty one still names
+// something that exists, so it stays legal.
+func TestEmptyContainersAreAllowed(t *testing.T) {
+	for _, src := range []string{"module M\nend", "record R\nend"} {
+		parseOK(t, src)
+	}
+}
+
+// The empty-body diagnostic must not set the parser's panicking flag. That flag
+// suppresses the cascade from a parser that has lost its place, and this parser
+// has not: it knows where it is and carries on correctly, so a second empty body
+// further down is a separate mistake and has to be reported too.
+func TestEmptyBodiesDoNotSuppressLaterDiagnostics(t *testing.T) {
+	const src = "if true\nend\nfor i in 1..3\nend"
+	_, bag := parse(t, src)
+	if bag.Len() != 2 {
+		t.Fatalf("got %d diagnostics, want 2 (one per empty body):\n%s", bag.Len(), bag.Render())
+	}
+}
+
+// A construct still being typed has an empty block for the same reason it has no
+// `end` yet. Reporting an empty body there would turn the REPL's "keep typing"
+// into an error, so nothing is reported at end of input and the missing-'end'
+// diagnostic is the one that stands.
+func TestUnterminatedConstructIsIncompleteNotEmpty(t *testing.T) {
+	for _, src := range []string{"if true", "for i in 1..3", "let f = func ()"} {
+		_, bag := parse(t, src)
+		if !bag.Incomplete() {
+			t.Errorf("%q: want a single incomplete-input diagnostic, got:\n%s", src, bag.Render())
+		}
+		if strings.Contains(bag.Render(), "empty ") {
+			t.Errorf("%q: reported an empty body while still incomplete:\n%s", src, bag.Render())
+		}
+	}
+}

--- a/testdata/semantics/control/block-expression.ari
+++ b/testdata/semantics/control/block-expression.ari
@@ -16,10 +16,10 @@ end
 println(y)
 println(outer)
 
-// It nests, and an empty one is nil like any other empty body.
+// It nests. An empty one is rejected, like any other empty body; see
+// errors/parse-empty-do-body.ari.
 println(do
   do
     "inner"
   end
 end)
-println(do end)

--- a/testdata/semantics/control/block-expression.out
+++ b/testdata/semantics/control/block-expression.out
@@ -2,5 +2,4 @@
 shadowed
 kept
 inner
-nil
 --- exit: 0

--- a/testdata/semantics/control/empty-containers.ari
+++ b/testdata/semantics/control/empty-containers.ari
@@ -1,0 +1,11 @@
+// A module and a record are containers, not bodies. An empty one still names
+// something that exists, so it stays legal where an empty body does not.
+module Empty
+end
+println(typeof(Empty))
+
+record Unit
+end
+println(Unit())
+println(Unit() == Unit())
+println(typeof(Unit()))

--- a/testdata/semantics/control/empty-containers.out
+++ b/testdata/semantics/control/empty-containers.out
@@ -1,0 +1,5 @@
+Module
+Unit()
+true
+Unit
+--- exit: 0

--- a/testdata/semantics/errors/parse-empty-do-body.ari
+++ b/testdata/semantics/errors/parse-empty-do-body.ari
@@ -1,0 +1,1 @@
+println(do end)

--- a/testdata/semantics/errors/parse-empty-do-body.out
+++ b/testdata/semantics/errors/parse-empty-do-body.out
@@ -1,0 +1,4 @@
+parse-empty-do-body.ari:1:12: error: empty do body; write nil if it is meant to do nothing
+  println(do end)
+             ^^^
+--- exit: 1

--- a/testdata/semantics/errors/parse-empty-for-body.ari
+++ b/testdata/semantics/errors/parse-empty-for-body.ari
@@ -1,0 +1,2 @@
+for i in 1..3
+end

--- a/testdata/semantics/errors/parse-empty-for-body.out
+++ b/testdata/semantics/errors/parse-empty-for-body.out
@@ -1,0 +1,4 @@
+parse-empty-for-body.ari:1:14: error: empty for body; write nil if it is meant to do nothing
+  for i in 1..3
+               ^
+--- exit: 1

--- a/testdata/semantics/errors/parse-empty-if-body.out
+++ b/testdata/semantics/errors/parse-empty-if-body.out
@@ -1,2 +1,4 @@
-
---- exit: 0
+parse-empty-if-body.ari:1:13: error: empty if body; write nil if it is meant to do nothing
+  if true then
+              ^
+--- exit: 1


### PR DESCRIPTION
The last entry under Known Gaps, and the one item where deciding late would be a breaking change, so it belongs before 1.0. The original rejected empty bodies in four places; the rewrite accepted them everywhere as a side effect of blocks becoming ordinary node lists, and the constructs added since inherited that without anyone choosing it.

A `for` is the reason it matters: the loop collects a value per iteration, so `for i in 1..1000000 end` quietly builds a million-element array of nils.

## What changed

- Every block holding code to run rejects an empty one: `if`, `else`, `for`, `while`, `until`, `func`, `do`, `try`, `rescue`, and a `switch` arm or `default`. The message names the construct and suggests `nil`.
- `module` and `record` still accept an empty body. Both name something that exists, which an empty body does not.
- The diagnostic goes to the bag rather than through `errorAt`, so it does not set `panicking` and a second empty body further down is still reported.
- Nothing is reported at end of input, so a half-typed `if true` in the REPL still means "keep typing" rather than becoming an error.
- Corrected the Known Gaps note, which claimed empty bodies evaluate to `nil` — true of everything except `for`, the one case where it mattered.
- Recorded the ruling in `docs/architecture.md`, documented the rule in the README, and added parser tests covering all eleven sites plus the two properties above.

A comment-only body counts as empty, since comments are not nodes. That caught three of the README's own placeholder examples, which now write `nil` beside the comment.

Two goldens changed, both intended: `errors/parse-empty-if-body` recorded exit 0 and now records the error, and `control/block-expression` loses its last line to a new case in `errors/` so the rest of its coverage survives.
