### PR TITLE
fix: Record names any record

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ go test ./internal/parser/  -run=Fuzz -fuzz=FuzzParse -fuzztime=30s
 
 ## The characterization suite is the arbiter
 
-`testdata/semantics/` holds 222 cases, each a `.ari` file with a `.out` golden recording
+`testdata/semantics/` holds 223 cases, each a `.ari` file with a `.out` golden recording
 exactly what the interpreter prints and what it exits with. Files prefixed with `_` are
 fixtures another case imports, and have no golden of their own.
 

--- a/README.md
+++ b/README.md
@@ -666,7 +666,7 @@ println(add(5, "two"))
 
 Aria is not a strong typed language, so type hinting is completely optional. Generally, it's a good idea to use it as a validation measure. Once you enforce a certain type, you'll be sure of how the function executes.
 
-A hint names one of `Nil`, `Bool`, `Int`, `Float`, `String`, `Atom`, `Array`, `Dictionary`, `Function`, `Module` or `Any`. Anything else is an error before the program runs, and the same goes for `is` and `as`. `Any` accepts everything, which is how you say "anything" out loud instead of by leaving the hint off:
+A hint names one of `Nil`, `Bool`, `Int`, `Float`, `String`, `Atom`, `Array`, `Dictionary`, `Function`, `Module`, `Record` or `Any`. A record's own name works too, so `Point` accepts that record and `Record` accepts any of them. Anything else is an error before the program runs, and the same goes for `is` and `as`. `Any` accepts everything, which is how you say "anything" out loud instead of by leaving the hint off:
 
 ```swift
 let identity = func (v: Any) -> Any

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -921,6 +921,28 @@ go test ./internal/scanner/ -run=Fuzz -fuzz=FuzzScan -fuzztime=30s
 go test ./internal/parser/  -run=Fuzz -fuzz=FuzzParse -fuzztime=30s
 ```
 
+### `Record` names any record
+
+`Record` was in the accepted set of type names and satisfied by nothing. `TypeName` answers
+a record's own name — identity being the point of having records rather than dictionaries —
+and every type check compared against that, so `Record` could only ever match a record
+literally called `Record`. A hint written with it resolved cleanly and then rejected every
+argument it was given.
+
+It now means "any record", which is what `Module` already meant for free, nothing having
+overridden its type name. `Point(1) is Record` is true, `Point(1) is Point` is still true,
+and `Point(1) is Size` is still false: the category is added without blurring the identities
+underneath it.
+
+The three rules live in `value.Satisfies` rather than at each site that asks. There are five
+— parameter hints, return hints, `is`, `case is`, and a record field — and every one of them
+was special-casing `Any` on its own, so `Record` would have been a second special case in
+five places.
+
+The reassignment type lock deliberately does not go through it. That check compares two
+values' names directly, because a `var` holding a `Point` must still refuse a `Size` even
+though both satisfy `Record`.
+
 ## What a release promises
 
 [compatibility.md](compatibility.md) is the user-facing half of this file: what a version

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -104,7 +104,7 @@ person at a terminal, not for a script to drive.
 Most projects cannot make a compatibility promise honestly, because they have no way to
 notice breaking it. Aria can:
 
-- **222 characterization cases** recording exactly what the interpreter prints and the code
+- **223 characterization cases** recording exactly what the interpreter prints and the code
   it exits with, run seven times each to catch anything that varies.
 - **140 README code blocks**, executed, because the documentation is where the promise is
   written down and an example that stopped working is a broken promise.

--- a/internal/interp/callable.go
+++ b/internal/interp/callable.go
@@ -180,8 +180,7 @@ func (i *Interp) callFunction(fn *Function, args []value.Value, span source.Span
 		i.signal, i.retval = sigNone, nil
 	}
 
-	if decl.ReturnType != nil && decl.ReturnType.Value != value.Any &&
-		value.TypeName(result) != decl.ReturnType.Value {
+	if decl.ReturnType != nil && !value.Satisfies(result, decl.ReturnType.Value) {
 		i.failIn(callerFile, span, "%s declares it returns %s but returned %s",
 			fnName(decl), decl.ReturnType.Value, value.TypeName(result))
 	}
@@ -189,10 +188,10 @@ func (i *Interp) callFunction(fn *Function, args []value.Value, span source.Span
 }
 
 func (i *Interp) checkParamType(p *ast.FunctionParameter, arg value.Value, file *source.File, span source.Span) {
-	if p.Type == nil || p.Type.Value == value.Any {
+	if p.Type == nil {
 		return
 	}
-	if value.TypeName(arg) != p.Type.Value {
+	if !value.Satisfies(arg, p.Type.Value) {
 		i.failIn(file, span, "parameter '%s' expects %s, got %s",
 			p.Name.Value, p.Type.Value, value.TypeName(arg))
 	}

--- a/internal/interp/interp.go
+++ b/internal/interp/interp.go
@@ -315,14 +315,11 @@ func (i *Interp) eval(n ast.Node, e *env) value.Value {
 	case *ast.Pipe:
 		return i.evalPipe(n, e)
 	case *ast.Is:
-		// `Any` is a name a hint may use, and everything is one.
-		if n.Right.Value == value.Any {
-			i.eval(n.Left, e)
-			return value.True
-		}
-		// TypeName, not Type().String(): a record answers its own name, which
-		// is the whole point of it having one.
-		return value.Of(value.TypeName(i.eval(n.Left, e)) == n.Right.Value)
+		// Evaluated whatever the name is: `x is Any` is true, but x may still
+		// have an effect worth having. Satisfies knows the three rules --
+		// `Any` matches everything, `Record` matches any record, and every
+		// other name matches exactly, so `x is Point` means that Point.
+		return value.Of(value.Satisfies(i.eval(n.Left, e), n.Right.Value))
 	case *ast.As:
 		return i.convert(i.eval(n.Left, e), n.Right.Value, n.Span())
 
@@ -839,12 +836,9 @@ func (i *Interp) caseValueMatches(el ast.Node, control value.Value, e *env) bool
 		return true
 
 	case *ast.TypeCase:
-		if el.Name.Value == value.Any {
-			return true
-		}
-		// TypeName, so `case is Point` matches a Point rather than every
-		// record.
-		return value.TypeName(control) == el.Name.Value
+		// `case is Point` matches a Point rather than every record, while
+		// `case is Record` matches any of them. See value.Satisfies.
+		return value.Satisfies(control, el.Name.Value)
 
 	case *ast.Array:
 		// An array literal in case position pattern-matches element by element,

--- a/internal/interp/records.go
+++ b/internal/interp/records.go
@@ -101,10 +101,10 @@ func (i *Interp) construct(def *RecordDef, args []value.Value, span source.Span)
 }
 
 func (i *Interp) checkFieldType(def *RecordDef, f *ast.FunctionParameter, v value.Value, file *source.File, span source.Span) {
-	if f.Type == nil || f.Type.Value == value.Any {
+	if f.Type == nil {
 		return
 	}
-	if value.TypeName(v) != f.Type.Value {
+	if !value.Satisfies(v, f.Type.Value) {
 		i.failIn(file, span, "%s field '%s' expects %s, got %s",
 			def.Def.Name, f.Name.Value, f.Type.Value, value.TypeName(v))
 	}

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -609,3 +609,31 @@ func TypeName(v Value) string {
 	}
 	return v.Type().String()
 }
+
+// Satisfies reports whether v answers to a declared type name.
+//
+// Three rules, in one place because five sites ask the question -- parameter
+// hints, return hints, `is`, a `case is`, and a record field -- and each of them
+// was special-casing Any on its own.
+//
+// Any matches everything, which is how a hint says "anything" out loud rather
+// than by being left off.
+//
+// Record matches any record. TypeName answers a record's own name, because
+// identity is the whole point of having records rather than dictionaries, so
+// without this rule `Record` would be satisfied only by a record literally
+// named Record -- and it is in the accepted set, so a hint could resolve and
+// then reject every argument. Module already reads this way for free, since
+// nothing overrides its type name.
+//
+// Everything else matches its own name exactly. In particular one record does
+// not satisfy another, which is what keeps a Point out of a var holding a Size.
+func Satisfies(v Value, typeName string) bool {
+	switch typeName {
+	case Any:
+		return true
+	case TRecord.String():
+		return v.Type() == TRecord
+	}
+	return TypeName(v) == typeName
+}

--- a/internal/value/value_test.go
+++ b/internal/value/value_test.go
@@ -350,3 +350,42 @@ func TestAtomAndStringKeyAlike(t *testing.T) {
 		t.Error("1 and \"1\" key alike")
 	}
 }
+
+// `Record` names any record, the way `Any` names anything and `Module` already
+// named any module. TypeName answers a record's own name, so before this rule
+// `Record` was in the accepted set of type names and satisfied by nothing: a
+// hint written with it resolved and then rejected every argument.
+//
+// What must not follow is one record satisfying another. That is what keeps a
+// Point out of a var declared holding a Size.
+func TestSatisfies(t *testing.T) {
+	point := NewRecord(&RecordType{Name: "Point", Fields: []string{"x"}}, []Value{Int(1)})
+	size := NewRecord(&RecordType{Name: "Size", Fields: []string{"x"}}, []Value{Int(1)})
+
+	tests := []struct {
+		name string
+		v    Value
+		typ  string
+		want bool
+	}{
+		{"record is Record", point, "Record", true},
+		{"other record is Record", size, "Record", true},
+		{"record is its own name", point, "Point", true},
+		{"record is not another record", point, "Size", false},
+		{"array is not Record", NewArray(nil), "Record", false},
+		{"dictionary is not Record", NewDict(nil), "Record", false},
+		{"int is not Record", Int(1), "Record", false},
+		{"record is Any", point, Any, true},
+		{"int is Any", Int(1), Any, true},
+		{"nil is Any", NilValue, Any, true},
+		{"int is Int", Int(1), "Int", true},
+		{"int is not String", Int(1), "String", false},
+		{"record is not Dictionary", point, "Dictionary", false},
+	}
+	for _, test := range tests {
+		if got := Satisfies(test.v, test.typ); got != test.want {
+			t.Errorf("%s: Satisfies(%s, %q) = %v, want %v",
+				test.name, TypeName(test.v), test.typ, got, test.want)
+		}
+	}
+}

--- a/testdata/semantics/records/record-type-name.ari
+++ b/testdata/semantics/records/record-type-name.ari
@@ -1,0 +1,44 @@
+// `Record` names any record, the way `Any` names anything. A record still
+// answers its own name to typeof and still satisfies only itself among records,
+// so `Record` adds a category without blurring the identities under it.
+record Point
+  x: Int
+end
+record Size
+  x: Int
+end
+
+println(Point(1) is Record)
+println(Point(1) is Point)
+println(Point(1) is Size)
+println(typeof(Point(1)))
+
+// Not a record, and a record is not a dictionary either.
+println([1] is Record)
+println([=>] is Record)
+println(42 is Record)
+println(Point(1) is Dictionary)
+
+// As a hint, in every position that takes one.
+let widen = func (r: Record) -> Record
+  r
+end
+println(widen(Point(1)))
+println(widen(Size(1)))
+
+record Boxed
+  inner: Record
+end
+println(Boxed(Point(1)))
+
+// In case position, specific before general.
+let describe = func (v)
+  switch v
+  case is Point then "a Point"
+  case is Record then "some other record"
+  default then "not a record"
+  end
+end
+println(describe(Point(1)))
+println(describe(Size(1)))
+println(describe("text"))

--- a/testdata/semantics/records/record-type-name.out
+++ b/testdata/semantics/records/record-type-name.out
@@ -1,0 +1,15 @@
+true
+true
+false
+Point
+false
+false
+false
+false
+Point(x: 1)
+Size(x: 1)
+Boxed(inner: Point(x: 1))
+a Point
+some other record
+not a record
+--- exit: 0


### PR DESCRIPTION
`Record` was in the accepted set of type names and satisfied by nothing. `value.TypeName` answers a record's own name, and every type check compared against that, so `Record` could only ever match a record literally called `Record` — a hint written with it resolved cleanly and then rejected every argument.

It now means "any record", which is what `Module` already meant for free. Closes #63.

## What changed

- Added `value.Satisfies`, holding the three rules in one place: `Any` matches everything, `Record` matches any record, everything else matches its own name exactly.
- Replaced the five sites that each special-cased `Any` on their own — parameter hints, return hints, `is`, `case is`, and record fields.
- Left the reassignment type lock comparing names directly, so a `var` holding a `Point` still refuses a `Size` even though both satisfy `Record`.
- Added `records/record-type-name.ari` covering it in every position that takes a type name, and a table test in `internal/value`.
- Added `Record` to the README's hint list, which had omitted it, with a note that a record's own name works as a hint too.

No existing golden moved, which is why this survived long enough to be found while writing the compatibility note: nothing covered the old behavior. It is covered now.
