### PR TITLE
fix: exit non-zero on a usage mistake, and stop String.first lying

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ go test ./internal/parser/  -run=Fuzz -fuzz=FuzzParse -fuzztime=30s
 
 ## The characterization suite is the arbiter
 
-`testdata/semantics/` holds 223 cases, each a `.ari` file with a `.out` golden recording
+`testdata/semantics/` holds 224 cases, each a `.ari` file with a `.out` golden recording
 exactly what the interpreter prints and what it exits with. Files prefixed with `_` are
 fixtures another case imports, and have no golden of their own.
 

--- a/aria.go
+++ b/aria.go
@@ -42,7 +42,25 @@ func main() {
 			runSource(source.NewFile("-e", []byte(src)), c.Args())
 			return nil
 		}
+		// An argument left over here is a command that does not exist, and this
+		// is where it lands: setting app.Action makes urfave/cli route unmatched
+		// arguments to it rather than to CommandNotFound, which is why that hook
+		// was dead code and has been removed. Without this, `aria rnu file.ari`
+		// printed the help and exited 0, so a typo in a script read as success.
+		if c.NArg() > 0 {
+			color.Red("Command %q doesn't exist.", c.Args().First())
+			os.Exit(2)
+		}
+		// No arguments at all is a request for help, not a mistake.
 		return cli.ShowAppHelp(c)
+	}
+
+	// A flag that does not exist is the same kind of mistake as a command that
+	// does not exist. By default it printed "Incorrect Usage" and exited 0.
+	app.OnUsageError = func(c *cli.Context, err error, isSubcommand bool) error {
+		color.Red("%s", err)
+		os.Exit(2)
+		return nil
 	}
 
 	app.Commands = []cli.Command{
@@ -63,11 +81,6 @@ func main() {
 			Usage:  "Start the interactive repl",
 			Action: runREPL,
 		},
-	}
-
-	app.CommandNotFound = func(ctx *cli.Context, command string) {
-		fmt.Fprintf(ctx.App.Writer, "Command %q doesn't exist.\n", command)
-		os.Exit(2)
 	}
 
 	if err := app.Run(os.Args); err != nil {

--- a/aria_test.go
+++ b/aria_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// The exit status is a contract docs/compatibility.md makes: 0 ran, 1 did not,
+// 2 is a usage mistake. It had nothing testing it and was wrong -- an unknown
+// command printed the help and exited 0, because setting app.Action makes
+// urfave/cli route unmatched arguments there instead of to CommandNotFound, so
+// a mistyped subcommand in a script read as success.
+//
+// This builds the binary rather than calling into main(), because the thing
+// under test is what the process returns to a shell.
+func buildAria(t *testing.T) string {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "aria")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+	build := exec.Command("go", "build", "-o", bin, ".")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("building the interpreter: %v\n%s", err, out)
+	}
+	return bin
+}
+
+func TestExitStatus(t *testing.T) {
+	bin := buildAria(t)
+	dir := t.TempDir()
+
+	write := func(name, src string) string {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte(src), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+
+	good := write("good.ari", "println(\"ok\")\n")
+	runtimeBad := write("runtime.ari", "println(1 / 0)\n")
+	resolveBad := write("resolve.ari", "let x = nope\n")
+	parseBad := write("parse.ari", "let x = (\n")
+
+	tests := []struct {
+		name string
+		args []string
+		want int
+	}{
+		{"run a good file", []string{"run", good}, 0},
+		{"check a good file", []string{"check", good}, 0},
+		{"evaluate with -e", []string{"-e", "println(1)"}, 0},
+		{"no arguments prints help", nil, 0},
+
+		{"a runtime failure", []string{"run", runtimeBad}, 1},
+		{"a name the resolver rejects", []string{"run", resolveBad}, 1},
+		{"a parse failure", []string{"run", parseBad}, 1},
+		{"check rejects a bad file", []string{"check", resolveBad}, 1},
+		{"a file that is not there", []string{"run", filepath.Join(dir, "nope.ari")}, 1},
+		{"a bad program via -e", []string{"-e", "let x = ("}, 1},
+
+		{"an unknown command", []string{"bogus"}, 2},
+		{"a mistyped command", []string{"rnu", good}, 2},
+		{"an unknown flag", []string{"--nope"}, 2},
+		{"run with no file", []string{"run"}, 2},
+		{"check with no file", []string{"check"}, 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := exec.Command(bin, tt.args...)
+			out, err := cmd.CombinedOutput()
+			got := 0
+			if err != nil {
+				var exit *exec.ExitError
+				if !errors.As(err, &exit) {
+					t.Fatalf("running %v: %v", tt.args, err)
+				}
+				got = exit.ExitCode()
+			}
+			if got != tt.want {
+				t.Errorf("aria %s exited %d, want %d\n%s",
+					strings.Join(tt.args, " "), got, tt.want, out)
+			}
+		})
+	}
+}
+
+// A usage mistake has to say so. Exiting 2 silently would be as unhelpful as
+// exiting 0, and the old behavior printed the whole help text, which buries the
+// one line that matters.
+func TestUsageMistakesSayWhat(t *testing.T) {
+	bin := buildAria(t)
+
+	for _, tt := range []struct{ args, want []string }{
+		{[]string{"bogus"}, []string{"bogus", "doesn't exist"}},
+		{[]string{"--nope"}, []string{"nope"}},
+	} {
+		out, _ := exec.Command(bin, tt.args...).CombinedOutput()
+		for _, want := range tt.want {
+			if !strings.Contains(string(out), want) {
+				t.Errorf("aria %s: output does not mention %q:\n%s",
+					strings.Join(tt.args, " "), want, out)
+			}
+		}
+	}
+}

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -31,7 +31,8 @@ For such a program, 1.x guarantees:
 2. **Semantics.** What the program computes, and what it prints when it prints a value.
 3. **The standard library.** Documented functions keep their names, their parameters and
    what they answer, tagged results included.
-4. **Exit status.** `0` when the program ran to completion. Non-zero when it did not.
+4. **Exit status.** `0` when the program ran to completion, `1` when it did not, and `2`
+   for a usage mistake such as an unknown command or an unknown flag.
 5. **The command line.** `run`, `check`, `repl`, `-e` and `-` keep working and keep meaning
    what they mean.
 
@@ -104,7 +105,7 @@ person at a terminal, not for a script to drive.
 Most projects cannot make a compatibility promise honestly, because they have no way to
 notice breaking it. Aria can:
 
-- **223 characterization cases** recording exactly what the interpreter prints and the code
+- **224 characterization cases** recording exactly what the interpreter prints and the code
   it exits with, run seven times each to catch anything that varies.
 - **140 README code blocks**, executed, because the documentation is where the promise is
   written down and an example that stopped working is a broken promise.

--- a/internal/stdlib/string.ari
+++ b/internal/stdlib/string.ari
@@ -8,11 +8,16 @@ module String
     runtime_len(str)
   end
 
-  let first = func (str: String) -> String
+  // No `-> String` on either of these. The body is a subscript, which answers
+  // nil on an empty string, and a declared return type would turn that into
+  // "declares it returns String but returned Nil" -- an internal contract
+  // violation shown to a caller who did nothing wrong. Enum.first and Enum.last
+  // have always answered nil the same way and carry no hint for the same reason.
+  let first = func (str: String)
     str[0]
   end
 
-  let last = func (str: String) -> String
+  let last = func (str: String)
     str[String.count(str) - 1]
   end
 

--- a/testdata/semantics/stdlib/string-first-last-empty.ari
+++ b/testdata/semantics/stdlib/string-first-last-empty.ari
@@ -1,0 +1,22 @@
+// String.first and String.last answer nil on an empty string, the way
+// Enum.first and Enum.last do on an empty array. They used to declare
+// `-> String`, so the empty case surfaced the interpreter's own return-type
+// check to a caller who had done nothing wrong.
+println(String.first(""))
+println(String.last(""))
+println(Enum.first([]))
+println(Enum.last([]))
+
+// The non-empty case is unchanged, and still counts runes rather than bytes.
+println(String.first("abc"))
+println(String.last("abc"))
+println(String.first("héllo"))
+println(String.last("naïve"))
+
+// Nothing catchable is raised, so a caller can test the answer directly.
+println(String.first("") == nil)
+println(try
+  String.first("")
+rescue e
+  "raised: #{e.message}"
+end)

--- a/testdata/semantics/stdlib/string-first-last-empty.out
+++ b/testdata/semantics/stdlib/string-first-last-empty.out
@@ -1,0 +1,11 @@
+nil
+nil
+nil
+nil
+a
+c
+h
+e
+true
+nil
+--- exit: 0


### PR DESCRIPTION
Two findings from the pre-1.0 audit, both of which a tag would have made permanent.

`aria bogus` printed the help and exited **0**, as did `aria --nope`. A mistyped subcommand or flag in a script read as success. The `CommandNotFound` hook meant to catch this exited 2 and never ran — setting `app.Action`, which `aria -e '...'` needs, makes urfave/cli route unmatched arguments to the action instead of the hook, so it has been dead since `-e` was added.

`String.first("")` failed with `function (str) declares it returns String but returned Nil` — the interpreter's own return-type check shown to a caller who did nothing wrong.

## What changed

- Removed the dead `CommandNotFound` hook; the action reports an unknown command itself and exits 2. `OnUsageError` covers the unknown-flag half. An argument-less `aria` still prints help and exits 0, which is a request for help rather than a mistake.
- Added `aria_test.go`, covering all fifteen exit-status paths by building the binary and running it, since what is under test is what the process hands back to a shell.
- Made `docs/compatibility.md` specific: `0` ran, `1` did not, `2` is a usage mistake. It promised an exit status two commits ago with nothing testing it, which is how it came to be wrong the day it was written.
- Dropped the `-> String` hints from `String.first` and `String.last`, so both answer `nil` on an empty string exactly as `Enum.first` and `Enum.last` do. A sweep found no other library function whose declared return type its own body can violate.

No existing golden moved for either fix, which is why both survived to be found: nothing covered the behavior. Both are covered now.
