### PR TITLE
docs: correct six things the README got wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ shelf
     * [Atom](#atom)
     * [Int](#int)
     * [Float](#float)
-    * [Boolean](#boolean)
+    * [Bool](#bool)
     * [Array](#array)
     * [Dictionary](#dictionary)
     * [Nil](#nil)
@@ -150,7 +150,7 @@ var age = 40
 age = 41
 ```
 
-Names have to start with an alphabetic character and continue either with alphanumeric, underscores, questions marks or exclamation marks. When you see a question mark, don't confuse them with optionals like in some other languages. In here they have no special lexical meaning except that they allow for some nice variable names like `is_empty?` or `do_it!`.
+Names start with a letter or an underscore and continue with letters, digits, underscores, question marks or exclamation marks. Letter means any Unicode letter, so `café` and `λ` are names as much as `count` is. When you see a question mark, don't confuse them with optionals like in some other languages. In here they have no special lexical meaning except that they allow for some nice variable names like `is_empty?` or `do_it!`.
 
 ### Constants
 
@@ -183,7 +183,7 @@ nr = "ten" // error: nr holds Int
 
 ## Data Types
 
-Aria supports 7 data types: `String`, `Atom`, `Int`, `Float`, `Bool`, `Array`, `Dictionary` and `Nil`.
+Aria has 8 data types: `String`, `Atom`, `Int`, `Float`, `Bool`, `Array`, `Dictionary` and `Nil`. Functions, modules and records are values too, and `typeof` answers `Function`, `Module` and the record's own name for them, but they get their own sections rather than one here.
 
 ### String
 
@@ -194,7 +194,7 @@ let weather = "Hot"
 let price = "円500"
 ```
 
-String concatenation is handled with the `+` operator. Concats between a string and another data type will result in a runtime error.
+String concatenation is handled with the `+` operator. Adding anything other than a string is a runtime error, with one exception: an Atom concatenates, since atoms and strings are interchangeable to begin with, and you get its text without the colon.
 
 ```swift
 let name = "Tony" + " " + "Stark"
@@ -600,12 +600,16 @@ true == true
 ["a" => 1, "b" => 2] != ["a" => 5, "b" => 6]
 ```
 
-Boolean operators can only be used with Boolean values, namely `true` or `false`. Other data types will not be converted to truthy values.
+Boolean operators take anything and answer a Bool. Their operands are read for truthiness the same way an `if` reads its condition, so `0 || 5` is `true` rather than `5`, and they short-circuit:
 
 ```swift
 true == true
 false != true
+println(0 || 5)    // true, not 5
+println(nil || 5)  // true
 ```
+
+That is why `??` exists alongside `||`: it tests for `nil` rather than truthiness, and yields the value rather than a Bool.
 
 Bitwise and bitshift operator apply only to Integers. Float values can't be used, even those that "look" as Integers, like `1.0` or `5.0`. A shift count has to be between 0 and 63, and a left shift that would push bits past the sign bit is an error like any other overflow.
 
@@ -1167,8 +1171,6 @@ end
 ```
 
 Unlike the `for`, they evaluate to `nil`. A `for` collects every iteration's value into an array, which is great when you want it and wasteful when you don't. These two are for when you don't.
-
-*The `for` loop is currently naively parsed. It works for most cases, but still, it's not robust enough. I'm working to find a better solution.*
 
 ## Range Operator
 


### PR DESCRIPTION
`check-readme.sh` runs the code blocks, so the prose around them has never been checked by anything. The pre-1.0 audit read it against the implementation and found six wrong claims, one of which the README already contradicted elsewhere in its own text.

## What changed

- **Boolean operators.** "can only be used with Boolean values … will not be converted to truthy values" — both halves false. `0 || 5` is `true`, `nil || 5` is `true`, and operands are read for truthiness the way an `if` reads its condition. The nil-coalescing section already printed `0 || 5 // true` to explain why `??` exists, so the README disagreed with itself.
- **The type count.** "Aria supports 7 data types" followed by a list of eight, omitting `Function`, `Module` and `Record`. Now 8, counted correctly, pointing at the three with sections of their own.
- **String concatenation.** "Concats between a string and another data type will result in a runtime error" holds for every type but `Atom`, which concatenates and contributes its text without the colon.
- **Identifiers.** "Names have to start with an alphabetic character" is wrong twice: a leading underscore works, and the scanner takes any Unicode letter, so `café` and `λ` are names.
- **The for loop.** The "currently naively parsed, I'm working to find a better solution" note describes the parser that was replaced.
- **A dead link.** The table of contents pointed at `#boolean` for a heading called `Bool`.

No code changed. 140 blocks, 0 unexplained, anchors all resolve.
