### PR TITLE
feat: codepoint conversion, and say why an alias cannot carry a module

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ go test ./internal/parser/  -run=Fuzz -fuzz=FuzzParse -fuzztime=30s
 
 ## The characterization suite is the arbiter
 
-`testdata/semantics/` holds 224 cases, each a `.ari` file with a `.out` golden recording
+`testdata/semantics/` holds 226 cases, each a `.ari` file with a `.out` golden recording
 exactly what the interpreter prints and what it exits with. Files prefixed with `_` are
 fixtures another case imports, and have no golden of their own.
 

--- a/README.md
+++ b/README.md
@@ -1438,6 +1438,8 @@ println(Geo.area(3, 4))
 
 An alias is a module, so it's checked like any other one and a member that isn't there gets you a diagnostic instead of a surprise at runtime. Import cycles are fine, as a file that's already been pulled in won't be pulled in twice.
 
+Because an alias is a module, and a module body holds only `let`, a file that declares its own `module` or `record` can't be aliased. It doesn't need to be either, since it already namespaces itself, so import it without the `as` and use the name it gave you.
+
 A more useful pattern would be to wrap imported files into a module. That would make for a more intuitive system and prevent scope leakage. The cat case above could be written simply into:
 
 ```swift
@@ -1577,7 +1579,7 @@ The Standard Library is fully written in Aria with the help of a few essential f
 
 Nine modules come with it:
 
-**`String`**: `count`, `isEmpty?`, `first`, `last`, `lower`, `upper`, `capitalize`, `reverse`, `slice`, `repeat`, `padLeft`, `padRight`, `trim`, `trimLeft`, `trimRight`, `join`, `split`, `lines`, `words`, `indexOf`, `lastIndexOf`, `starts?`, `ends?`, `contains?`, `replace`, `match?`.
+**`String`**: `count`, `isEmpty?`, `first`, `last`, `code`, `fromCode`, `lower`, `upper`, `capitalize`, `reverse`, `slice`, `repeat`, `padLeft`, `padRight`, `trim`, `trimLeft`, `trimRight`, `join`, `split`, `lines`, `words`, `indexOf`, `lastIndexOf`, `starts?`, `ends?`, `contains?`, `replace`, `match?`.
 
 `trim` and its two halves strip whitespace, unless you hand them a set of characters to strip instead, and they strip every leading or trailing occurrence of it:
 
@@ -1587,6 +1589,17 @@ String.trimLeft("xxhi", "x") // "hi"
 ```
 
 `indexOf` and `lastIndexOf` answer with `-1` when there's nothing to find, so "not found" doesn't get confused with "found at 0".
+
+`code` and `fromCode` go between a character and its codepoint, which is what you need whenever a character is computed rather than written down. Codepoints and not bytes, like everything else about strings here:
+
+```swift
+println(String.code("A"))       // 65
+println(String.fromCode(233))   // "é"
+println(String.code("😀"))      // 128512
+println(String.code(""))        // nil, like String.first
+```
+
+A number that isn't a codepoint raises, since that's the caller's arithmetic being wrong rather than an outcome to handle.
 
 **`Math`**: `pi`, `e`, `infinity`, `nan`, `floor`, `ceil`, `round`, `trunc`, `max`, `min`, `clamp`, `random`, `abs`, `sign`, `pow`, `sqrt`, `cbrt`, `exp`, `log`, `log2`, `log10`, `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `isNaN?`, `isInfinite?`.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -943,6 +943,44 @@ The reassignment type lock deliberately does not go through it. That check compa
 values' names directly, because a `var` holding a `Point` must still refuse a `Size` even
 though both satisfy `Record`.
 
+### An alias cannot carry a module or a record
+
+`import "file" as Name` works by resolving the unit into a scope of its own and turning that
+scope into a module, which is why aliasing needed no machinery the language did not already
+have. The catch is that a module body holds only `let`: modules do not nest and a record
+cannot live in one, enforced everywhere a module is written by hand.
+
+So a `module` or `record` declared in an aliased file has nowhere to go, and it used to go
+nowhere quietly. Both halves of the implementation collected members from `ast.Let` and
+`ast.Var` only, so the declaration was dropped by the resolver and by `defineModule` alike.
+Neither `Lib.Shapes` nor a bare `Shapes` resolved, and the diagnostic named the alias, which
+reads as a typo in the caller rather than as a problem with the import.
+
+Making it work would mean modules that nest and records inside modules, reachable only
+through an aliased import and never writable by hand, which is a language change to serve
+one corner. The other direction is cheap and honest: a file that declares a module already
+namespaces itself, which is the whole job of the alias, so the two are redundant. It is now
+an error saying exactly that, reported against the declaration in the file that made it.
+
+### A codepoint and a character, in both directions
+
+Strings index by rune and a literal can name a codepoint with `\u{...}`, but nothing went
+between an `Int` and a character, so a computed character was unreachable: ciphers, base
+conversion, and any interpreter with an output instruction. `examples/brainfuck.ari` carried
+95 characters of printable ASCII as a lookup table to print anything at all.
+
+`String.code` answers the first rune's codepoint, and `nil` for an empty string, the way
+`String.first` does. There is no codepoint to give, and an empty string is ordinary data.
+`String.fromCode` raises for a number that is not a codepoint, a surrogate included, because
+that is the caller's arithmetic being wrong rather than an outcome to handle. Go answers
+U+FFFD for both, which would turn the mistake into a replacement character that travels
+instead of an error where it happened.
+
+The two builtin lists, `resolver.Builtins` and the evaluator's `def` calls, had nothing
+tying them together, and adding these to the evaluator alone made the standard library fail
+to resolve with no hint that a list elsewhere was short. `TestBuiltinListsAgree` compares
+them now.
+
 ## What a release promises
 
 [compatibility.md](compatibility.md) is the user-facing half of this file: what a version

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -105,7 +105,7 @@ person at a terminal, not for a script to drive.
 Most projects cannot make a compatibility promise honestly, because they have no way to
 notice breaking it. Aria can:
 
-- **224 characterization cases** recording exactly what the interpreter prints and the code
+- **226 characterization cases** recording exactly what the interpreter prints and the code
   it exits with, run seven times each to catch anything that varies.
 - **140 README code blocks**, executed, because the documentation is where the promise is
   written down and an example that stopped working is a broken promise.

--- a/examples/brainfuck.ari
+++ b/examples/brainfuck.ari
@@ -21,16 +21,6 @@ let jumps = func (source: String) -> Dictionary
   state[1]
 end
 
-// The standard library has no codepoint-to-character function, so this indexes
-// a table of printable ASCII. See the note at the bottom.
-let printable = " !" + "\"" + "#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[" + "\\" + "]^_`abcdefghijklmnopqrstuvwxyz{|}~"
-
-let char = func (code: Int) -> String
-  if code == 10 then return "\n" end
-  if code < 32 || code > 126 then return "?" end
-  printable[code - 32]
-end
-
 let run = func (source: String) -> String
   let table = jumps(source)
   let width = String.count(source)
@@ -46,7 +36,7 @@ let run = func (source: String) -> String
     case "<" then head -= 1
     case "+" then tape[head] = (tape[head] + 1) % 256
     case "-" then tape[head] = (tape[head] + 255) % 256
-    case "." then out += char(tape[head])
+    case "." then out += String.fromCode(tape[head])
     case "[" then
       if tape[head] == 0 then pc = table[pc] end
     case "]" then
@@ -64,7 +54,3 @@ println(run("++++++++[>++++[>++>+++>+++>+<<<<-]>+>+>->>+[<]<-]>>.>---.+++++++..+
 
 // Adding two cells: 2 + 5, printed as the character '7'.
 println(run("++>+++++[<+>-]<++++++++++++++++++++++++++++++++++++++++++++++++."))
-
-// Note: `char` exists because the standard library has no way to turn a
-// codepoint into a character. String indexing goes the other way fine. Adding
-// String.code and String.fromCode would remove the table entirely.

--- a/internal/interp/builtins.go
+++ b/internal/interp/builtins.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/fadion/aria/internal/source"
@@ -327,6 +328,38 @@ func (i *Interp) installBuiltins() {
 			ip.fail(span, "runtime_repeat() expects a non-negative count")
 		}
 		return value.String(strings.Repeat(string(str), int(times)))
+	})
+
+	// A codepoint and a character, in both directions. Strings index by rune and
+	// a literal can name a codepoint with \u{...}, but neither direction was
+	// reachable from a value, so a computed character was out of reach --
+	// ciphers, base conversion, and any interpreter with an output instruction.
+	def("runtime_from_code", func(ip *Interp, args []value.Value, span source.Span) value.Value {
+		ip.wantArgs("runtime_from_code", args, 1, span)
+		code, ok := args[0].(value.Int)
+		if !ok {
+			ip.fail(span, "runtime_from_code() expects an Int, got %s", args[0].Type())
+		}
+		// Go answers U+FFFD for anything that is not a codepoint, which would
+		// turn a caller's arithmetic mistake into a replacement character that
+		// travels instead of an error where it happened. Surrogates go the same
+		// way: they are not characters, and encoding one also yields U+FFFD.
+		if code < 0 || code > unicode.MaxRune || (code >= 0xD800 && code <= 0xDFFF) {
+			ip.fail(span, "runtime_from_code() expects a Unicode codepoint, got %d", int64(code))
+		}
+		return value.String(string(rune(code)))
+	})
+
+	def("runtime_code", func(ip *Interp, args []value.Value, span source.Span) value.Value {
+		str := ip.wantString("runtime_code", args, span)
+		// Nil for an empty string, the way a subscript past the end answers nil
+		// and String.first answers nil. There is no codepoint to give, and an
+		// empty string is ordinary data rather than a caller's mistake.
+		if str == "" {
+			return value.NilValue
+		}
+		r, _ := utf8.DecodeRuneInString(str)
+		return value.Int(r)
 	})
 
 	def("runtime_reverse", func(ip *Interp, args []value.Value, span source.Span) value.Value {

--- a/internal/interp/builtins_drift_test.go
+++ b/internal/interp/builtins_drift_test.go
@@ -1,0 +1,59 @@
+package interp
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/fadion/aria/internal/resolver"
+	"github.com/fadion/aria/internal/source"
+)
+
+// The resolver keeps its own list of builtin names so it can reject an
+// undefined one before the program runs, and the evaluator installs the real
+// functions. Nothing tied the two together, so a builtin added to one and not
+// the other compiled fine and failed at the worst moment: adding runtime_code
+// and runtime_from_code to the evaluator alone made the standard library itself
+// fail to resolve, with "internal error: the standard library failed to
+// compile" and no hint that a list elsewhere was short.
+func TestBuiltinListsAgree(t *testing.T) {
+	i := New(source.NewFile("test.ari", nil), nil)
+
+	installed := []string{}
+	for name, v := range i.globals.vars {
+		if _, ok := v.(*Builtin); ok {
+			installed = append(installed, name)
+		}
+	}
+
+	declared := map[string]bool{}
+	for _, name := range resolver.Builtins {
+		declared[name] = true
+	}
+	have := map[string]bool{}
+	for _, name := range installed {
+		have[name] = true
+	}
+
+	var missing, extra []string
+	for _, name := range installed {
+		if !declared[name] {
+			missing = append(missing, name)
+		}
+	}
+	for _, name := range resolver.Builtins {
+		if !have[name] {
+			extra = append(extra, name)
+		}
+	}
+	sort.Strings(missing)
+	sort.Strings(extra)
+
+	if len(missing) > 0 {
+		t.Errorf("installed by the evaluator but not in resolver.Builtins, so the "+
+			"resolver will reject any call to them: %v", missing)
+	}
+	if len(extra) > 0 {
+		t.Errorf("in resolver.Builtins but never installed, so a call resolves and "+
+			"then fails at runtime: %v", extra)
+	}
+}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -42,6 +42,7 @@ var Builtins = []string{
 	"runtime_len", "runtime_slice", "runtime_index_of", "runtime_last_index_of",
 	"runtime_split", "runtime_replace",
 	"runtime_join", "runtime_repeat", "runtime_reverse",
+	"runtime_code", "runtime_from_code",
 	"runtime_sort", "runtime_has_key",
 	"runtime_read_file", "runtime_write_file", "runtime_append_file",
 	"runtime_remove_file", "runtime_file_exists",
@@ -275,6 +276,10 @@ func (r *Resolver) IncludeNamespaced(file *source.File, prog *ast.Program, diags
 			if n.Name != nil {
 				members = append(members, n.Name.Value)
 			}
+		case *ast.Module:
+			r.aliasedDeclaration(n.Name, alias, "module")
+		case *ast.Record:
+			r.aliasedDeclaration(n.Name, alias, "record")
 		}
 	}
 	r.pop(prog)
@@ -282,6 +287,27 @@ func (r *Resolver) IncludeNamespaced(file *source.File, prog *ast.Program, diags
 	r.modules[alias] = true
 	r.predeclare(alias, KindLet)
 	r.moduleMembers[r.current.names[alias]] = members
+}
+
+// aliasedDeclaration reports a module or record in a file imported under an
+// alias.
+//
+// An alias works by making the unit's scope a module, and a module body holds
+// only `let` -- modules do not nest and a record cannot live in one, which is
+// enforced everywhere a module is written by hand. So there is nowhere for such
+// a declaration to go, and it used to go nowhere silently: neither `Geo.Shapes`
+// nor a bare `Shapes` resolved, and the diagnostic named the alias, which reads
+// as a typo in the caller rather than a problem with the import.
+//
+// A file that declares a module already namespaces itself, which is what the
+// alias was for, so the fix is to drop one of the two. The message says so.
+func (r *Resolver) aliasedDeclaration(name *ast.Identifier, alias, kind string) {
+	if name == nil {
+		return
+	}
+	r.diags.Errorf(name.Span(),
+		"%s '%s' cannot be reached through the alias '%s': a module holds only 'let', so import this file without 'as %s' and use '%s' directly",
+		kind, name.Value, alias, alias, name.Value)
 }
 
 // unit resolves one program's nodes into the current scope.

--- a/internal/stdlib/string.ari
+++ b/internal/stdlib/string.ari
@@ -21,6 +21,22 @@ module String
     str[String.count(str) - 1]
   end
 
+  // A codepoint and a character, in both directions. Aria strings index by
+  // rune, so these are codepoints and not bytes: String.code("é") is 233, and
+  // String.fromCode(233) is "é".
+  //
+  // code answers nil for an empty string, the way first and last do, because
+  // there is no codepoint to give and an empty string is ordinary data.
+  // fromCode raises for a number that is not a codepoint, because that is the
+  // caller's arithmetic being wrong rather than an outcome to handle.
+  let code = func (str: String)
+    runtime_code(str)
+  end
+
+  let fromCode = func (code: Int) -> String
+    runtime_from_code(code)
+  end
+
   let lower = func (str: String) -> String
     runtime_tolower(str)
   end

--- a/testdata/semantics/errors/_aliased.ari
+++ b/testdata/semantics/errors/_aliased.ari
@@ -1,0 +1,7 @@
+module Shapes
+  let area = func (r) do r * r end
+end
+record Point
+  x: Int
+end
+let plain = 42

--- a/testdata/semantics/errors/import-alias-module.ari
+++ b/testdata/semantics/errors/import-alias-module.ari
@@ -1,0 +1,5 @@
+// A module or a record in a file imported under an alias cannot be reached:
+// an alias works by making the unit's scope a module, and a module body holds
+// only `let`. Reported against the declaration, in the file that made it.
+import "_aliased" as Lib
+println(Lib.plain)

--- a/testdata/semantics/errors/import-alias-module.out
+++ b/testdata/semantics/errors/import-alias-module.out
@@ -1,0 +1,7 @@
+_aliased.ari:1:8: error: module 'Shapes' cannot be reached through the alias 'Lib': a module holds only 'let', so import this file without 'as Lib' and use 'Shapes' directly
+  module Shapes
+         ^^^^^^
+_aliased.ari:4:8: error: record 'Point' cannot be reached through the alias 'Lib': a module holds only 'let', so import this file without 'as Lib' and use 'Point' directly
+  record Point
+         ^^^^^
+--- exit: 1

--- a/testdata/semantics/stdlib/string-code.ari
+++ b/testdata/semantics/stdlib/string-code.ari
@@ -1,0 +1,38 @@
+// A codepoint and a character, in both directions. Codepoints, not bytes:
+// strings index by rune everywhere else too.
+println(String.code("A"))
+println(String.fromCode(65))
+println(String.code("é"))
+println(String.fromCode(233))
+println(String.code("😀"))
+println(String.fromCode(128512))
+
+// code reads the first rune of a longer string.
+println(String.code("abc"))
+
+// Round trips.
+println(String.fromCode(String.code("λ")))
+println(String.fromCode(10) == "\n")
+
+// Empty is nil, the way String.first is: no codepoint to give, and an empty
+// string is ordinary data rather than a caller's mistake.
+println(String.code(""))
+
+// A number that is not a codepoint raises, because that is the caller's
+// arithmetic being wrong. Go would answer U+FFFD and let it travel.
+println(try
+  String.fromCode(-1)
+rescue e
+  e.message
+end)
+println(try
+  String.fromCode(1114112)
+rescue e
+  e.message
+end)
+// Surrogates are not characters.
+println(try
+  String.fromCode(55296)
+rescue e
+  e.message
+end)

--- a/testdata/semantics/stdlib/string-code.out
+++ b/testdata/semantics/stdlib/string-code.out
@@ -1,0 +1,14 @@
+65
+A
+233
+é
+128512
+😀
+97
+λ
+true
+nil
+runtime_from_code() expects a Unicode codepoint, got -1
+runtime_from_code() expects a Unicode codepoint, got 1114112
+runtime_from_code() expects a Unicode codepoint, got 55296
+--- exit: 0


### PR DESCRIPTION
The last two open issues, cleared so 1.0 ships with nothing outstanding. Closes #59, closes #60.

## What changed

**#59 — a module or record in an aliased import.** `import "f" as Name` resolves the unit into its own scope and makes that scope a module, but a module body holds only `let`: modules don't nest and a record can't live in one. So such a declaration had nowhere to go and went nowhere silently — neither `Lib.Shapes` nor a bare `Shapes` resolved, and the diagnostic named the alias, reading as a typo in the caller.

Making it work would mean nested modules and records-inside-modules, reachable only through an aliased import and never writable by hand. Instead: a file that declares a module already namespaces itself, which is the alias's whole job, so the two are redundant. That's now an error saying exactly that, reported against the declaration in the file that made it, listing every one rather than just the first.

**#60 — codepoint conversion.** Added `String.code` and `String.fromCode` over two new builtins. `code` answers the first rune's codepoint, and `nil` for an empty string the way `String.first` does. `fromCode` raises for a number that isn't a codepoint, surrogates included — Go answers U+FFFD, which would turn a caller's arithmetic mistake into a replacement character that travels instead of an error where it happened.

`examples/brainfuck.ari` carried 95 characters of printable ASCII as a lookup table to print anything; it now calls `String.fromCode` and is 14 lines shorter with byte-identical output.

**Found on the way:** `resolver.Builtins` and the evaluator's `def()` calls are two lists of the same thing with nothing tying them together. Adding these to the evaluator alone made the standard library itself fail to resolve, with no hint that a list elsewhere was short. `TestBuiltinListsAgree` compares them, and was verified against the drift it exists to catch.

No existing golden moved. 226 cases, 141 README blocks, 20 examples.
