### PR TITLE
release: 1.0.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,7 +176,7 @@ run that command, so the next tag needs the prefix for it to be true.
 refuses a tag that disagrees with it. Bump it in the same commit you tag.
 
 ```bash
-git tag v0.6.0 && git push origin v0.6.0
+git tag v1.0.0 && git push origin v1.0.0
 ```
 
 That builds six archives, checksums them, and publishes a release. A pull request

--- a/aria.go
+++ b/aria.go
@@ -16,7 +16,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-const version = "0.6.0"
+const version = "1.0.0"
 
 func main() {
 	app := cli.NewApp()

--- a/examples/pretty-print.ari
+++ b/examples/pretty-print.ari
@@ -31,7 +31,7 @@ end
 
 let config = [
   "name" => "aria",
-  "version" => "0.6.0",
+  "version" => "1.0.0",
   "toy" => true,
   "authors" => ["fadion"],
   "limits" => ["depth" => 100, "timeout" => 3.5],

--- a/examples/pretty-print.out
+++ b/examples/pretty-print.out
@@ -10,6 +10,6 @@
   name: "aria"
   notes: null
   toy: true
-  version: "0.6.0"
+  version: "1.0.0"
 }
 exit: 0


### PR DESCRIPTION
The version the binary reports. The release workflow refuses a tag that disagrees with `const version`, so this lands before `v1.0.0` is pushed.

1.0 is a promise rather than a milestone: breaking changes start costing a major bump. [docs/compatibility.md](docs/compatibility.md) says what that covers and, more usefully, what it does not.

It's worth making now because nothing is outstanding — the 25-issue backlog is cleared, the pre-1.0 audit's findings are fixed, both remaining issues are closed, and Known Gaps holds one entry that is a performance question rather than a semantic one.

## What changed

- `const version` in `aria.go`, from `0.6.0` to `1.0.0`.
- `CLAUDE.md`'s tag example, so it follows the constant.
- The `pretty-print` example's sample config, which named the old version in data that reads as this project's own, plus its golden.

## Tagging

The tag has to be `v1.0.0`. The workflow accepts an unprefixed tag for the sake of the pre-0.6 ones, but the module proxy does not — an unprefixed tag is why `go install github.com/fadion/aria@latest` spent years resolving to a 2017 pseudo-version.

226 characterization cases, 141 README blocks, 20 examples, all green.
