### PR TITLE
docs: a security policy and a changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,120 @@
+# Changelog
+
+Notable changes per release. [docs/compatibility.md](docs/compatibility.md) says
+what a version number promises; the short version is that from 1.0 on, a working
+program keeps working, and a breaking change costs a major.
+
+**Breaking** marks a change that can stop an existing program from running or
+change what it computes. Diagnostic wording is not covered by the promise and is
+not tracked here.
+
+## 1.0.0
+
+The first release with a compatibility promise attached. Everything below landed
+between 0.6.0 and 1.0.0.
+
+### Language
+
+- **Records.** `record Point x: Int end` gives structured data a type. Fields are
+  a parameter list, so constructing one is an ordinary call with the same arity
+  check, type hints and defaults. `typeof` answers the record's own name, and two
+  records with the same fields are still different types.
+- **Recoverable errors, in two shapes.** Tagged `[:ok, v]` / `[:error, why]`
+  results for outcomes a caller should expect, and `try`/`rescue` for faults,
+  including ones the runtime raised. The library draws the line at data versus
+  misuse.
+- **Destructuring.** `let [a, b] = pair`, with `_` as a hole, `...name` for the
+  rest, and nesting. In a `switch` arm, `let name` captures what matched.
+- **`switch` guards, type cases and range cases.** `case 1..9 when n % 2 == 0`,
+  and `case is Int`.
+- **Files, arguments, environment and a clock.** `File`, `OS` and `Time`, where
+  `prompt` had been the only way out of the process.
+- **Imports are one compilation.** An imported file is resolved with the file that
+  imports it, so a mistake in one is reported before anything runs, in the file
+  it was made in. `import "f" as Name` namespaces what it brings in, and cycles
+  terminate.
+- **String interpolation** with `#{}`, raw strings in backticks, and `\u{...}`
+  escapes.
+- **`while`, `until`, and `break N`.** A `for` collects a value per iteration;
+  these are for when that array is not wanted.
+- **`??`, `?.`, and `do ... end` as an expression.**
+- **Lazy ranges in a `for`, and slicing** with `a[1..3]`.
+- **Line continuation.** An expression spans lines when a line ends with an
+  operator or begins with one, and a parenthesised parameter list can span lines.
+- **Top-level functions hoist**, so two of them can call each other without a
+  module.
+- **Modules are values**, and `.` is an operator over expressions rather than a
+  form over two names.
+- **`|>` takes a bare name**, and `_` marks the slot when the piped value does
+  not belong first.
+- **Type annotations are checked before the program runs**, including a default
+  against its own parameter's hint.
+
+### Breaking
+
+- **Integer arithmetic fails rather than wraps.** An operation whose result does
+  not fit in a 64-bit signed integer is an error, not a plausible-looking
+  negative number. `Float % 0.0` raises.
+- **Collections have no order**, so `<`, `<=`, `>` and `>=` are no longer defined
+  on arrays and dictionaries. Compare sizes explicitly with `Enum.size` or
+  `Dict.size`.
+- **An atom keys as the string of its text**, so `:a` and `"a"` are the same
+  dictionary key and compare equal.
+- **A comma-separated `case` list is alternatives**, and a pattern is an array
+  literal. The same syntax used to mean both, chosen by the runtime type of the
+  subject.
+- **An empty body is an error** in `if`, `else`, `for`, `while`, **`until`**,
+  `func`, `do`, `try`, `rescue` and a `switch` arm. A comment is not a node, so a
+  body holding only a comment is empty; write `nil` for a deliberate no-op.
+  `module` and `record` still take an empty body.
+- **`Record` names any record.** It was an accepted type name that no value
+  satisfied, so a hint written with it resolved and then rejected every argument.
+- **A module or record in an aliased import is an error.** An alias makes the
+  unit's scope a module, and a module body holds only `let`, so there was nowhere
+  for the declaration to go and it went nowhere silently. Import such a file
+  without `as`.
+- **`String.first("")` and `String.last("")` answer `nil`** instead of failing
+  with the interpreter's own return-type error. They match `Enum.first` and
+  `Enum.last` now.
+- **Stray control keywords are rejected**, along with `_` out of position and
+  too many `for` loop variables.
+- **A usage mistake exits 2.** An unknown command or flag printed help and exited
+  `0`, so a typo in a script read as success.
+
+### Standard library
+
+- `Result`: `ok`, `error`, `ok?`, `error?`, `unwrap`, `expect`, `reason`,
+  `attempt`.
+- `File`, `OS` and `Time`.
+- `String.code` and `String.fromCode`, between a character and its codepoint.
+- Filled the `String`, `Math`, `Enum` and `Dict` coverage gaps; `Enum.sort`
+  orders with the language's own `<`, and `sortBy` takes a key function.
+- Fixed `String.trim`, `String.join` on non-strings, and `Math.floor`/`ceil` on
+  negatives.
+- The runtime gained the primitives the library had been reimplementing in Aria,
+  which were quadratic inside the loops that called them.
+
+### Tooling
+
+- `aria check` parses and resolves without running, for CI or an editor.
+- `aria -e` evaluates a one-liner, and `aria run -` reads standard input.
+- The REPL reads whole constructs rather than lines, with `:load`, `:vars`,
+  `:modules` and `:help`.
+- A runtime error is located in the file its span indexes into, which had been
+  the importing file.
+
+### Documentation and testing
+
+- [docs/compatibility.md](docs/compatibility.md), [docs/architecture.md](docs/architecture.md),
+  [SECURITY.md](SECURITY.md), and twenty runnable [examples](examples/).
+- 226 characterization cases, 141 executed README code blocks, and 20 examples
+  with goldens, all run in CI on three platforms alongside the fuzzers.
+
+## 0.6.0 and earlier
+
+Not tracked here. 0.x broke things freely, which is what 0.x is for.
+
+The tags through 0.5.0 carry no `v` prefix, and the module proxy does not
+recognise those, so `go install github.com/fadion/aria@latest` resolved to a 2017
+pseudo-version, the newest commit with no version attached to it, until v0.6.0
+became the first prefixed tag.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ shelf
 * [Files, Arguments, Environment and Time](#files-arguments-environment-and-time)
 * [Standard Library](#standard-library)
 
-_Working on the interpreter itself? [docs/architecture.md](docs/architecture.md) covers how it's put together and why the design decisions went the way they did. [docs/compatibility.md](docs/compatibility.md) says what a version number promises and what it doesn't._
+_Working on the interpreter itself? [docs/architecture.md](docs/architecture.md) covers how it's put together and why the design decisions went the way they did. [docs/compatibility.md](docs/compatibility.md) says what a version number promises and what it doesn't, [CHANGELOG.md](CHANGELOG.md) what changed per release, and [SECURITY.md](SECURITY.md) what is and isn't a vulnerability in a language with no sandbox._
 
 ## Usage
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,66 @@
+# Security
+
+## Aria runs untrusted code as you
+
+There is no sandbox, and there is not meant to be one. An Aria program reads and
+writes any path the process can, sets and reads environment variables, and
+`import` reaches any file it is given a path to. Running an Aria program you did
+not write is running a program you did not write, with everything your account
+can do.
+
+That is a design position rather than an oversight, and it is the thing to know
+before wiring the interpreter into anything that accepts source from elsewhere:
+a build step, a plugin system, a web service, a CI job that runs a contributed
+script. If you need to run untrusted Aria, put the sandbox around the process
+yourself: a container, a jail, a user with nothing to lose. The language will not
+provide one.
+
+So the following are **not** vulnerabilities, and a report of one will be closed
+with a link to this paragraph:
+
+- An Aria program reading or writing files, including outside its directory.
+- An Aria program reading the environment, or the command line.
+- `import` reaching a file anywhere on disk.
+- An Aria program exhausting memory or CPU. Recursion is bounded and parse
+  nesting is bounded, both so that a runaway program fails with a diagnostic
+  rather than a stack overflow, but neither is a resource limit.
+
+## What is worth reporting
+
+A way to make the **interpreter itself** misbehave on input that should have been
+rejected or handled:
+
+- A crash in Go: a panic, a nil dereference, an index out of range, a stack
+  overflow. Aria source should produce an Aria diagnostic, never a Go trace. The
+  scanner and parser are fuzzed continuously for this, and a case they missed is
+  worth having.
+- A hang or an infinite loop in the scanner, parser or resolver on some input.
+  Every path through the scanner consumes a byte specifically so that the token
+  stream terminates; a counterexample is a real bug.
+- Memory that grows without bound while merely reading a program, before it runs.
+- Anything in the release pipeline: a published archive whose contents do not
+  match its source, or a checksum that does not verify.
+
+## Reporting
+
+Open a [private security advisory](https://github.com/fadion/aria/security/advisories/new),
+which reaches the maintainer without making the report public first.
+
+Include the input, what happened, and what you expected. A failing `.ari` file is
+the most useful thing you can send, and if a fuzzer found it, the corpus entry is
+better still.
+
+This is a toy language maintained by one person in their own time. There is no
+response-time commitment, no bounty, and no embargo policy beyond common sense.
+What there is: a characterization suite that makes a fix provable, and a genuine
+interest in any input that makes the interpreter do something other than
+diagnose it.
+
+## Supported versions
+
+The most recent release. There are no maintenance branches, and a fix ships in
+the next version rather than being backported.
+
+[docs/compatibility.md](docs/compatibility.md) covers what a version number
+promises. Worth noting here: diagnostic wording is explicitly not covered, so a
+security fix that changes an error message is not a breaking change.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -9,7 +9,7 @@ because each of them has an edge worth naming before somebody finds it the hard 
 
 ## Version numbers
 
-Releases are tagged `vX.Y.Z`. The `v` is not decoration — Go's module proxy only recognises
+Releases are tagged `vX.Y.Z`. The `v` is not decoration: Go's module proxy only recognises
 a version tagged that way.
 
 | | |
@@ -64,7 +64,7 @@ that changes when the failure arrives and what came out on stdout first.
 Making something legal that used to be rejected is additive, and lands in a minor. Nothing
 that worked stops working, because the thing in question did not work.
 
-That covers every syntax decision currently deferred — nullable and union type
+That covers every syntax decision currently deferred. Nullable and union type
 annotations, record and dictionary destructuring by name, and named call arguments are each
 a parse or resolve error today, so none of them needs a major to arrive.
 
@@ -86,8 +86,8 @@ diagnostic rather than a stack overflow. The exact numbers may move, in either d
 
 ### Anything under `internal/`
 
-Go enforces this — those packages cannot be imported from outside the module — which is
-also the point. The scanner, parser, resolver, evaluator and value types are implementation.
+Go enforces this, since those packages cannot be imported from outside the module, and
+that is also the point. The scanner, parser, resolver, evaluator and value types are implementation.
 There is no Go API promise, and the pkg.go.dev listing is not one.
 
 ### Performance


### PR DESCRIPTION
Two gaps a 1.0 with a compatibility promise should not ship with.

## What changed

**`SECURITY.md`** exists mostly to say what is *not* a vulnerability. Aria has no sandbox and is not meant to: a program reads and writes any path the process can, and `import` reaches anywhere it is pointed. Someone will eventually report file access as a security hole, and the useful answer is a paragraph written before the report rather than after it. The other half says what is worth reporting — a Go panic, a hang in the scanner or parser, unbounded memory while merely reading a program, an archive that does not match its source — and points at private advisories. It is honest that this is one person's toy language with no response-time commitment.

**`CHANGELOG.md`** because `docs/compatibility.md` already promises deprecations are announced "in both sets of release notes", and the release workflow uses `--generate-notes`, which is a list of PR titles. Fine for a patch, not enough for a major, where the reader's question is "what breaks". The 1.0.0 entry keeps a **Breaking** section separate, covering the eleven changes since 0.6.0 that can stop an existing program.

Both are linked from the README's header note, alongside the two docs already there.

One correction while writing it: the changelog first said `go install` resolved to a 2017 pseudo-version "until 1.0.0". It was `v0.6.0` that fixed that, being the first tag with a `v` on it.

No em dashes in either, or in `compatibility.md`, which had three. That is the README's convention and these are read the same way. `architecture.md` and `CLAUDE.md` keep theirs, being notes for whoever works on the interpreter.
