### PR TITLE
docs: 141 README blocks, not 140

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -107,7 +107,7 @@ notice breaking it. Aria can:
 
 - **226 characterization cases** recording exactly what the interpreter prints and the code
   it exits with, run seven times each to catch anything that varies.
-- **140 README code blocks**, executed, because the documentation is where the promise is
+- **141 README code blocks**, executed, because the documentation is where the promise is
   written down and an example that stopped working is a broken promise.
 - **20 examples**, each with a golden.
 


### PR DESCRIPTION
A block was added in #66 to show that boolean operators coerce their operands, and the count in `docs/compatibility.md` was the one place not updated with it.

It is also the first change confined to `docs/`, which is what proves the CI restructure in #69 does what it claims: the four heavy jobs should report **skipped** rather than sitting **pending**. That is the difference between a required check that is satisfied and one that never arrives, and it is the only part of #69 that could not be tested by #69 itself.
