### PR TITLE
ci: one check for branch protection to require

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,3 +219,35 @@ jobs:
           name: fuzz-corpus
           path: internal/*/testdata/fuzz/
           if-no-files-found: ignore
+
+  # One check for branch protection to require, instead of seven.
+  #
+  # Requiring the job names directly has two problems. A skipped matrix job
+  # reports its name unexpanded -- literally "test (${{ matrix.os }})" rather
+  # than the three real ones -- so a required "test (ubuntu-latest)" waits
+  # forever on a documentation change, which is the deadlock the job-level
+  # filtering was meant to avoid in the first place. And every required name is
+  # coupled to a job name: rename a job, and protection silently stops enforcing
+  # it with nothing anywhere to notice.
+  #
+  # This job always runs, so it always reports, and it fails if anything it
+  # gates on failed or was cancelled. Skipped is fine: that is the filtering
+  # working. Require this and nothing else.
+  ci:
+    name: ci
+    if: always()
+    needs: [changes, test, lint, language, fuzz]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check what the other jobs did
+        env:
+          RESULTS: ${{ join(needs.*.result, ' ') }}
+        run: |
+          echo "results: $RESULTS"
+          case " $RESULTS " in
+            *" failure "*|*" cancelled "*)
+              echo "::error::a job this gates on did not pass"
+              exit 1
+              ;;
+          esac
+          echo "all clear"


### PR DESCRIPTION
Requiring the seven job names deadlocked the first documentation-only PR (#71), and not for the reason #69 anticipated.

Skipping works: `lint`, `language` and `fuzz` all reported **skipping**, which is a conclusion and satisfies a required check. But a skipped **matrix** job reports its name *unexpanded* — literally `test (${{ matrix.os }})` rather than the three real ones — so `test (ubuntu-latest)` and its siblings never arrived, and the PR sat `BLOCKED` on checks that cannot exist. The same deadlock #69 set out to prevent, one level down.

Requiring individual job names has a second problem worth fixing while here: every required name is coupled to a job name, so renaming a job silently stops protection enforcing it, with nothing anywhere to notice.

## What changed

- Added a `ci` job that always runs, gates on the other five, and fails if any failed or was cancelled. Skipped is fine — that is the filtering working. It always reports because it always runs.
- The comparison pads both sides (`case " $RESULTS " in *" failure "*`) so a status containing another as a substring cannot match by accident. Checked against all-success, all-skipped, a failure, a cancellation, and a failure among skips.

## After merging

Branch protection should require **`ci`** and nothing else, replacing the seven. Adding a job later then needs no ruleset change, and renaming one cannot quietly disable enforcement.
