### PR TITLE
ci: run the examples suite before a release too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,10 @@ jobs:
       - name: Examples
         run: bash scripts/check-examples.sh
 
+      # Adding a suite here means adding it to the release workflow's `verify`
+      # job too. Nothing enforces that the two agree, and the last time they
+      # drifted it was this step that was missing from a release.
+
   # Cheap, and both targets have found real bugs. 30s each, as in CLAUDE.md.
   fuzz:
     needs: changes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,11 +51,16 @@ jobs:
           fi
           echo "version $version"
 
+      # The same correctness suites the CI workflow's `language` job runs, so a
+      # tag cannot publish something master would have rejected. These two lists
+      # have to agree: check-examples.sh was added to CI and not here, and went
+      # missing from every release until somebody thought to compare them.
       - run: go build -o aria .
       - run: go vet ./...
       - run: go test ./...
       - run: bash scripts/characterize.sh verify
       - run: bash scripts/check-readme.sh
+      - run: bash scripts/check-examples.sh
 
   build:
     name: ${{ matrix.name }}


### PR DESCRIPTION
The release workflow's `verify` job runs the characterization suite and the README blocks, and did not run the examples. `check-examples.sh` was added to CI in #58 and never mirrored here, so a tag could publish a commit whose examples were broken. `v1.0.0` was not, but only because CI caught them on master first, which is luck rather than a guarantee.

## What changed

- `verify` now runs `scripts/check-examples.sh`, so both workflows run the same three correctness suites.
- Both files carry a comment pointing at the other. Nothing enforces that the lists agree, which is how they drifted in the first place.

Collapsing the three into one script would remove the drift outright, at the cost of what the separate steps buy: a failure attributed to the suite that failed rather than to a wrapper. Not worth trading for two files that change about once a year.

Note this PR touches `.github/workflows/release.yml`, so the release workflow builds all six archives without publishing, exercising the packaging alongside the change.
